### PR TITLE
Fix #16 : the sender and receiver url are absolute

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
@@ -140,11 +140,7 @@ public class Utils {
       kudos.setReceiverIdentityId(getIdentityIdByType(receiverIdentity));
       kudos.setReceiverType(USER_ACCOUNT_TYPE);
       kudos.setReceiverFullName(receiverIdentity.getProfile().getFullName());
-      try {
-        kudos.setReceiverURL(Util.getBaseUrl() + LinkProvider.getUserProfileUri(receiverIdentity.getRemoteId()));
-      } catch (Exception e) {
-        kudos.setReceiverURL(LinkProvider.getUserProfileUri(receiverIdentity.getRemoteId()));
-      }
+      kudos.setReceiverURL(LinkProvider.getUserProfileUri(receiverIdentity.getRemoteId()));
       kudos.setReceiverAvatar(getAvatar(receiverIdentity, null));
     } else {
       Space space = getSpace(String.valueOf(kudosEntity.getReceiverId()));
@@ -153,13 +149,7 @@ public class Utils {
         kudos.setReceiverIdentityId(String.valueOf(kudosEntity.getReceiverId()));
         kudos.setReceiverType(SPACE_ACCOUNT_TYPE);
         kudos.setReceiverFullName(space.getDisplayName());
-        try {
-          kudos.setReceiverURL(Util.getBaseUrl()
-              + LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", "")));
-        } catch (Exception e) {
-          kudos.setReceiverURL(LinkProvider.getActivityUriForSpace(space.getPrettyName(),
-                                                                   space.getGroupId().replace("/spaces/", "")));
-        }
+        kudos.setReceiverURL(LinkProvider.getActivityUriForSpace(space.getPrettyName(), space.getGroupId().replace("/spaces/", "")));
         kudos.setReceiverAvatar(getAvatar(null, space));
       }
     }
@@ -168,11 +158,7 @@ public class Utils {
     kudos.setSenderId(senderIdentity.getRemoteId());
     kudos.setSenderIdentityId(getIdentityIdByType(senderIdentity));
     kudos.setSenderFullName(senderIdentity.getProfile().getFullName());
-    try {
-      kudos.setSenderURL(Util.getBaseUrl() + LinkProvider.getUserProfileUri(senderIdentity.getRemoteId()));
-    } catch (Exception e) {
-      kudos.setSenderURL(LinkProvider.getUserProfileUri(senderIdentity.getRemoteId()));
-    }
+    kudos.setSenderURL(LinkProvider.getUserProfileUri(senderIdentity.getRemoteId()));
     kudos.setSenderAvatar(getAvatar(senderIdentity, null));
     return kudos;
   }


### PR DESCRIPTION
Prior to this change, url generated in SOC_ACTIVITY_TEMPLATE_PARAMS are generated as absolute url
This can lead to problem if the server name changes.
This fix remove the absolute part to generate only a relative url