### PR TITLE
Display kudos sender list in reactions drawer

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -107,10 +107,9 @@ export function registerExternalExtensions(title) {
   document.dispatchEvent(new CustomEvent('profile-extension-updated', { detail: profileExtensionAction}));
 }
 
-export function registerActivityReactionTabs(activityType, activityId,kudosNumber,
-                                             kudosList) {
+export function registerActivityReactionTabs(activityType, activityId,kudosNumber, kudosList) {
   const activityExtensionReaction = {
-    id: 'kudos',
+    id: `kudos-${activityId}`,
     icon: 'fa fa-award uiIconKudos',
     order: 3,
     activityType: activityType,


### PR DESCRIPTION
This bug fix the list of kudos senders in the reactions drawer, we add a single id to display the list of kudos for each activity in the activities stream