### PR TITLE
MAINT-27057: Make sure that for the action receive kudos the user is rewarded by the right points in gamification.

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/GamificationIntegrationListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/GamificationIntegrationListener.java
@@ -63,8 +63,8 @@ public class GamificationIntegrationListener extends Listener<KudosService, Kudo
         Map<String, String> gam = new HashMap<>();
         gam.put("ruleTitle", "sendKudos");
         gam.put("object", activityURL);
-        gam.put("senderId", kudos.getSenderId());
-        gam.put("receiverId", kudos.getSenderId());
+        gam.put("senderId", kudos.getSenderId()); // matches the gamification's earner id
+        gam.put("receiverId", kudos.getReceiverId());
         listenerService.broadcast(GAMIFICATION_GENERIC_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
       } catch (Exception e) {
         LOG.error("Cannot broadcast gamification event");
@@ -74,8 +74,8 @@ public class GamificationIntegrationListener extends Listener<KudosService, Kudo
         Map<String, String> gam = new HashMap<>();
         gam.put("ruleTitle", "receiveKudos");
         gam.put("object", activityURL);
-        gam.put("senderId", kudos.getSenderId());
-        gam.put("receiverId", kudos.getReceiverId());
+        gam.put("senderId", kudos.getReceiverId()); // matches the gamification's earner id
+        gam.put("receiverId", kudos.getSenderId());
         listenerService.broadcast(GAMIFICATION_GENERIC_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
       } catch (Exception e) {
         LOG.error("Cannot broadcast gamification event");


### PR DESCRIPTION
When a user sends a kudos to another user he earns all the points in total 15 points (10 points for the sender and 5 points for the receiver). This is due to confusing implementation of the event listener which doesn't distinct between kudos (sender, receiver) and gamification points (earner (receiver), sender). I left a comment in order to know the right gamification's points earner.