### PR TITLE
TASK-43200 Add Id of Kudos profile extension

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -87,6 +87,7 @@ export function getPeriodDates(date, periodType) {
 
 export function registerExternalExtensions(title) {
   const profileExtensionAction = {
+    id: `profile-kudos`,
     title: title,
     icon: 'fa fa-award uiIconKudos uiIconLightBlue',
     order: 20,

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosAPI.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosAPI.vue
@@ -87,7 +87,11 @@ export default {
       eXo.social.tiptip = eXo.social.tiptip ? eXo.social.tiptip : {};
       eXo.social.tiptip.extraActions = eXo.social.tiptip.extraActions ? eXo.social.tiptip.extraActions : [];
       const sendKudosLabel = this.$t('exoplatform.kudos.button.sendKudos');
+      if (eXo.social.tiptip.extraActions.find(action => action.id === 'profile-kudos')) {
+        return;
+      }
       eXo.social.tiptip.extraActions.push({
+        id: 'profile-kudos',
         appendContentTo(divUIAction, ownerId, type) {
           if (!type || type === 'username' || type === 'user' || type === 'organization') {
             type = 'USER';


### PR DESCRIPTION
This modification is related to Meeds-io/gatein-portal#197

Prior to this change, when having the smooth navigation enabled, the Kudos button extension is included multiple times in the profile extension.
With this modification, that adds an id to the defined extension, we will ensure that adding the same extension twice is idempotent.