### PR TITLE
TASK-47234 Cache Kudos List with activity

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/activity/processor/ActivityKudosProcessor.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/activity/processor/ActivityKudosProcessor.java
@@ -1,0 +1,37 @@
+package org.exoplatform.kudos.activity.processor;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.social.core.BaseActivityProcessorPlugin;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+
+public class ActivityKudosProcessor extends BaseActivityProcessorPlugin {
+
+  private KudosService kudosService;
+
+  public ActivityKudosProcessor(KudosService kudosService, InitParams initParams) {
+    super(initParams);
+    this.kudosService = kudosService;
+  }
+
+  @Override
+  public void processActivity(ExoSocialActivity activity) {
+    if (activity.isComment()) {
+      return;
+    }
+    if (activity.getLinkedProcessedEntities() == null) {
+      activity.setLinkedProcessedEntities(new HashMap<>());
+    }
+    @SuppressWarnings("unchecked")
+    List<Kudos> linkedKudosList = (List<Kudos>) activity.getLinkedProcessedEntities().get("kudosList");
+    if (linkedKudosList == null) {
+      linkedKudosList = kudosService.getKudosListOfActivity(activity.getId());
+      activity.getLinkedProcessedEntities().put("kudosList", linkedKudosList);
+    }
+  }
+
+}

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosActivityListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosActivityListener.java
@@ -53,19 +53,7 @@ public class KudosActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void updateComment(ActivityLifeCycleEvent activityLifeCycleEvent) {
-    ExoSocialActivity activity = activityLifeCycleEvent.getSource();
-    if (activity.getType().equals(KUDOS_ACTIVITY_COMMENT_TYPE)) {
-      long activityId = org.exoplatform.kudos.service.utils.Utils.getActivityId(activity.getId());
-      Kudos kudos = kudosService.getKudosByActivityId(activityId);
-      if (kudos != null) {
-        String newMessage = activity.getTitle();
-        kudos.setMessage(newMessage);
-        kudosService.updateKudos(kudos);
-
-        org.exoplatform.kudos.service.utils.Utils.computeKudosActivityProperties(activity, kudos);
-        this.activityManager.updateActivity(activity, false);
-      }
-    }
+    updateActivity(activityLifeCycleEvent);
   }
 
   @Override

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
@@ -443,6 +443,17 @@ public class KudosService implements ExoKudosStatisticService, Startable {
       throw new IllegalAccessException("User " + currentUser.getUserId() + " isn't allowed to access kudos of activity with id "
           + activityId);
     }
+    return getKudosListOfActivity(activityId);
+  }
+
+  /**
+   * Retrieves the list of kudos for a given parent entity id and with a set of
+   * entity types
+   * 
+   * @param activityId {@link ExoSocialActivity} id
+   * @return {@link List} of {@link Kudos}
+   */
+  public List<Kudos> getKudosListOfActivity(String activityId) {
     return kudosStorage.getKudosListOfActivity(getActivityId(activityId));
   }
 

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -8,5 +8,6 @@
   <import>war:/conf/kudos/dynamic-container-configuration.xml</import>
   <import>war:/conf/kudos/notification-configuration.xml</import>
   <import>war:/conf/kudos/gamification-configuration.xml</import>
+  <import>war:/conf/kudos/activity-configuration.xml</import>
 
 </configuration>

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/activity-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/activity-configuration.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplaform.org/xml/ns/kernel_1_1.xsd http://www.exoplaform.org/xml/ns/kernel_1_1.xsd"
+  xmlns="http://www.exoplaform.org/xml/ns/kernel_1_1.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
+    <component-plugin>
+      <name>ActivityKudosProcessor</name>
+      <set-method>addProcessorPlugin</set-method>
+      <type>org.exoplatform.kudos.activity.processor.ActivityKudosProcessor</type>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <description>priority of this processor (lower are executed first)</description>
+          <value>20</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -1,7 +1,7 @@
 const kudosListByActivity = {};
 
 export function computeActivityKudosList(activity) {
-  const activityKudosListPromise = kudosListByActivity[activity.id] = getKudosListByActivity(activity.id);
+  const activityKudosListPromise = kudosListByActivity[activity.id] = (activity && activity.kudosList && Promise.resolve(activity.kudosList)) || getKudosListByActivity(activity.id);
   return activityKudosListPromise
     .then(kudosList => {
       kudosListByActivity[activity.id] = kudosList;


### PR DESCRIPTION
Prior to this change, the list of kudos of an activity are retrieved from database with a specific REST request for each activity. This change will avoid retrieving list of kudos from front end each time we display an activity by caching the list of kudos of an activity when retrieved in Ativity Storage layer.