### PR TITLE
TASK-47651 Fix Kudos Caching after save or Edit

### DIFF
--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/rest/KudosRestTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/rest/KudosRestTest.java
@@ -188,7 +188,7 @@ public class KudosRestTest extends BaseKudosRestTest {
     assertNull(kudosByActivity);
 
     ActivityManager activityManager = getService(ActivityManager.class);
-    new NewKudosSentActivityGeneratorListener(activityManager).onEvent(new Event<KudosService, Kudos>(null,
+    new NewKudosSentActivityGeneratorListener(activityManager, null).onEvent(new Event<KudosService, Kudos>(null,
                                                                                                       kudosService,
                                                                                                       kudos));
     List<Kudos> kudosList = kudosService.getKudosByEntity(kudos.getEntityType(), kudos.getEntityId(), 1);

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
@@ -493,7 +493,7 @@ public class KudosServiceTest extends BaseKudosTest {
     ActivityManager activityManager = getService(ActivityManager.class);
 
     listenerService.addListener(Utils.KUDOS_SENT_EVENT,
-                                new NewKudosSentActivityGeneratorListener(activityManager));
+                                new NewKudosSentActivityGeneratorListener(activityManager, null));
 
     listenerService.addListener(Utils.KUDOS_ACTIVITY_EVENT,
                                 new GamificationIntegrationListener(container, listenerService));


### PR DESCRIPTION
Prior to this change, the Kudos List of an activity or comment where cached before assigning an activity identifier to the Kudos. This fix will ensure to clear cached Activity once the activityId updated on Kudos