### PR TITLE
TASK-47665 Refresh Kudos Count after sending Kudos

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -1,5 +1,10 @@
 const kudosListByActivity = {};
 
+export function resetActivityKudosList(activity) {
+  delete activity.kudosList;
+  delete kudosListByActivity[activity.id];
+}
+
 export function computeActivityKudosList(activity) {
   const activityKudosListPromise = kudosListByActivity[activity.id] = (activity && activity.kudosList && Promise.resolve(activity.kudosList)) || getKudosListByActivity(activity.id);
   return activityKudosListPromise

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -122,19 +122,25 @@ export default {
     },
   },
   created() {
-    document.addEventListener('activity-comment-created', this.resetActivity);
+    this.$root.$on('activity-comment-created', this.resetActivity);
+    this.$root.$on('kudos-refresh-comment', this.resetActivityComments);
     this.init();
   },
   beforeDestroy() {
-    document.removeEventListener('activity-comment-created', this.resetActivity);
+    this.$root.$off('activity-comment-created', this.resetActivity);
+    this.$root.$off('kudos-refresh-comment', this.resetActivityComments);
   },
   methods: {
-    resetActivity(event) {
-      if (!this.comment) {
-        const activityId = event && event.detail && event.detail.activityId;
-        if (activityId === this.activity.id) {
-          this.init();
-        }
+    resetActivity(comment) {
+      if (!this.comment && comment && comment.activityId === this.activityId) {
+        this.$kudosService.resetActivityKudosList(this.activity);
+        this.init();
+        this.$root.$emit('kudos-refresh-comment', this.activity.id);
+      }
+    },
+    resetActivityComments(activityId) {
+      if (activityId && this.comment && activityId === this.activityId) {
+        this.init();
       }
     },
     init() {


### PR DESCRIPTION
Prior to this change, the sent kudos list isn't refreshed on Kudos activity&comment buttons. This fix will retrieve again all Kudos of an activity to force update of Kudos buttons, once a kudos i sent.