### PR TITLE
TASK-49230 : fix kudos notification displayed with tags

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/web/KudosReceiverWebPlugin.gtmpl
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/web/KudosReceiverWebPlugin.gtmpl
@@ -36,8 +36,9 @@
         <% } %>
         <% if(org.apache.commons.lang3.StringUtils.isNotBlank(KUDOS_MESSAGE)) { %>
           <div class="content">
+          <% String kudosMessage = KUDOS_MESSAGE.replaceAll("\\&lt;.+?&gt;","") %>
             <i class="uiIcon fa fa-award uiIconKudos uiIconBlue"></i>
-            <%= KUDOS_MESSAGE %>
+            <%= kudosMessage %>
           </div>
         <% } %>
         <div class="lastUpdatedTime">$LAST_UPDATED_TIME</div>


### PR DESCRIPTION
Before this fix , when sending a kudos to someone the kudos notification message is displayed with tags in the notification top bar . This was fixed by by sanitizing the kudos message in a computed proprety  