### PR TITLE
TASK-50403 : fix period label translation in kudos drawer

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -246,7 +246,7 @@ export default {
       return this.remainingDaysToReset === 1 ? this.$t('exoplatform.kudos.label.day') : this.$t('exoplatform.kudos.label.days') ;
     },
     kudosPeriodLabel () {
-      return this.$t('exoplatform.kudos.label.'.concat(this.kudosPeriodType));
+      return this.$t(`exoplatform.kudos.label.${this.kudosPeriodType}`);
     },
     kudosMessageText() {
       return this.kudosMessage && this.$utils.htmlToText(this.kudosMessage);

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -45,7 +45,7 @@
                 <div class="d-flex flex-row">
                   <div>
                     <span class="text-sm-caption text-sub-title">
-                      {{ $t('exooplatform.kudos.label.numberOfKudos', {0: numberOfKudosAllowed , 1: kudosPeriodType, 2: kudosSent , 3: numberOfKudosAllowed}) }}
+                      {{ $t('exooplatform.kudos.label.numberOfKudos', {0: numberOfKudosAllowed , 1: kudosPeriodLabel, 2: kudosSent , 3: numberOfKudosAllowed}) }}
                     </span>
                   </div>
                   <div
@@ -244,6 +244,9 @@ export default {
     },
     remainingPeriodLabel() {
       return this.remainingDaysToReset === 1 ? this.$t('exoplatform.kudos.label.day') : this.$t('exoplatform.kudos.label.days') ;
+    },
+    kudosPeriodLabel () {
+      return this.$t('exoplatform.kudos.label.'.concat(this.kudosPeriodType));
     },
     kudosMessageText() {
       return this.kudosMessage && this.$utils.htmlToText(this.kudosMessage);


### PR DESCRIPTION
Before this fix , the kudos period in the kudos drawer is not translated and always assigned the value fetched from the database. 
this was fixed by displaying the period value stored in the label . 