### PR TITLE
TASK-50403 : fix period label translation in kudos drawer

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -195,6 +195,7 @@ export default {
       allKudos: [],
       kudosToSend: null,
       kudosMessage: '',
+      kudosPeriodType: '',
       loading: false,
       requiredField: false,
     };


### PR DESCRIPTION
Before this fix , the kudos period in the kudos drawer is not translated and always assigned the value fetched from the database.
this was fixed by displaying the period value stored in the label . 