### PR TITLE
TASK-50504 : improve the display of kudos icon in the drawer

### DIFF
--- a/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
+++ b/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
@@ -44,7 +44,8 @@ exoplatform.kudos.label.received=Received
 exoplatform.kudos.label.sent=Sent
 exoplatform.kudos.label.selectPeriodDate=Select the period
 exoplatform.kudos.label.kudosMessage=Message
-exooplatform.kudos.label.numberOfKudos=On {0} kudos allowed per {1} : {2}/{3} sent
+exooplatform.kudos.label.numberOfKudosAllowed=On {0} kudos allowed per {1} :
+exooplatform.kudos.label.numberOfKudosSent={0}/{1} sent
 
 exoplatform.kudos.label.kudosMessagePlaceholder=Enter the message to send along with your kudos
 exoplatform.kudos.label.to=to

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -28,11 +28,11 @@
           class="flex mx-4 pt-3">
           <div class="d-flex flex-column flex-grow-1">
             <div class="d-flex flex-row">
-              <div class="d-flex flex-column flex-grow-1">
+              <div class="d-flex flex-column flex-grow">
                 <span class="text-header-title my-auto mt-7 text-no-wrap">{{ $t('exoplatform.kudos.content.to') }} </span>
               </div>
-              <div class="d-flex flex-column pr-2 pt-3">
-                <div class="d-flex flex-row pt-3">
+              <div class="d-flex flex-column pr-2 pl-5 pt-3">
+                <div class="pt-3">
                   <exo-user-avatar
                     :username="kudosReceiver.receiverId"
                     :fullname="kudosReceiver.fullName"
@@ -43,28 +43,44 @@
                     size="32" />
                 </div>
                 <div class="d-flex flex-row">
-                  <div>
+                  <div class="d-flex flex-column">
+                    <div class="d-flex flex-row">
+                      <span class="text-sm-caption text-sub-title">
+                        {{ $t('exooplatform.kudos.label.numberOfKudosAllowed', {0: numberOfKudosAllowed , 1: kudosPeriodLabel}) }}
+                      </span>
+                      <div
+                        v-if="kudosSent || remainingKudos"
+                        class=" mx-2 pl-15">
+                        <div v-if="numberOfKudosAllowed <= numberOfKudosToDisplay">
+                          <v-icon
+                            v-for="index in remainingKudos"
+                            :key="index"
+                            class="uiIconKudos uiIconGrey pl-1"
+                            size="20">
+                            fa-award
+                          </v-icon>
+                          <v-icon
+                            v-for="index in kudosSent"
+                            :key="index"
+                            class="uiIconKudos uiIconBlue pl-1"
+                            size="20">
+                            fa-award
+                          </v-icon>
+                        </div>
+                        <div v-else>
+                          <v-icon
+                            v-for="index in numberOfKudosToDisplay"
+                            :key="index"
+                            class="uiIconKudos uiIconBlue pl-1"
+                            size="20">
+                            fa-award
+                          </v-icon>
+                        </div>
+                      </div>
+                    </div>
                     <span class="text-sm-caption text-sub-title">
-                      {{ $t('exooplatform.kudos.label.numberOfKudos', {0: numberOfKudosAllowed , 1: kudosPeriodLabel, 2: kudosSent , 3: numberOfKudosAllowed}) }}
+                      {{ $t('exooplatform.kudos.label.numberOfKudosSent', {0: kudosSent , 1: numberOfKudosAllowed}) }}
                     </span>
-                  </div>
-                  <div
-                    v-if="kudosSent || remainingKudos"
-                    class="pl-9">
-                    <v-icon
-                      v-for="index in remainingKudos"
-                      :key="index"
-                      class="uiIconKudos uiIconBlue pl-1"
-                      size="20">
-                      fa-award
-                    </v-icon>
-                    <v-icon
-                      v-for="index in kudosSent"
-                      :key="index"
-                      class="uiIconKudos uiIconGrey pl-1"
-                      size="20">
-                      fa-award
-                    </v-icon>
                   </div>
                 </div>
               </div>
@@ -174,6 +190,7 @@ export default {
   data() {
     return {
       numberOfKudosAllowed: 0,
+      numberOfKudosToDisplay: 3,
       listDialog: false,
       ignoreRefresh: false,
       kudosList: false,

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -48,40 +48,40 @@
                       <span class="text-sm-caption text-sub-title">
                         {{ $t('exooplatform.kudos.label.numberOfKudosAllowed', {0: numberOfKudosAllowed , 1: kudosPeriodLabel}) }}
                       </span>
-                      <div
-                        v-if="kudosSent || remainingKudos"
-                        class=" mx-2 pl-15">
-                        <div v-if="numberOfKudosAllowed <= numberOfKudosToDisplay">
-                          <v-icon
-                            v-for="index in remainingKudos"
-                            :key="index"
-                            class="uiIconKudos uiIconGrey pl-1"
-                            size="20">
-                            fa-award
-                          </v-icon>
-                          <v-icon
-                            v-for="index in kudosSent"
-                            :key="index"
-                            class="uiIconKudos uiIconBlue pl-1"
-                            size="20">
-                            fa-award
-                          </v-icon>
-                        </div>
-                        <div v-else>
-                          <v-icon
-                            v-for="index in numberOfKudosToDisplay"
-                            :key="index"
-                            class="uiIconKudos uiIconBlue pl-1"
-                            size="20">
-                            fa-award
-                          </v-icon>
-                        </div>
-                      </div>
                     </div>
                     <span class="text-sm-caption text-sub-title">
                       {{ $t('exooplatform.kudos.label.numberOfKudosSent', {0: kudosSent , 1: numberOfKudosAllowed}) }}
                     </span>
                   </div>
+                </div>
+              </div>
+              <div
+                v-if="kudosSent || remainingKudos"
+                class="flex d-flex justify-end pt-15">
+                <div v-if="numberOfKudosAllowed <= numberOfKudosToDisplay">
+                  <v-icon
+                    v-for="index in remainingKudos"
+                    :key="index"
+                    class="uiIconKudos uiIconGrey pl-1"
+                    size="20">
+                    fa-award
+                  </v-icon>
+                  <v-icon
+                    v-for="index in kudosSent"
+                    :key="index"
+                    class="uiIconKudos uiIconBlue pl-1"
+                    size="20">
+                    fa-award
+                  </v-icon>
+                </div>
+                <div v-else>
+                  <v-icon
+                    v-for="index in numberOfKudosToDisplay"
+                    :key="index"
+                    class="uiIconKudos uiIconBlue pl-1"
+                    size="20">
+                    fa-award
+                  </v-icon>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Before these changes , when the kudos number is bigger than 3 ,  the display of the number of kudos allowed and of the kudos icons becomes messed up due to the fact that all the icons are displayed in the drawer forcing the "number of kudos message" to be displayed in two lines . so i refactored the UI to allow the display of only 3 icons and to display the" number of kudos message"  on 2 lines. 