### PR TITLE
TASK-49875 : kudos email and push notifications are displayed with tags

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/builder/KudosTemplateBuilder.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/builder/KudosTemplateBuilder.java
@@ -19,6 +19,8 @@ import org.exoplatform.commons.api.notification.service.template.TemplateContext
 import org.exoplatform.commons.notification.template.TemplateUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessorImpl;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -35,9 +37,12 @@ public class KudosTemplateBuilder extends AbstractTemplateBuilder {
 
   private boolean          pushNotification;
 
-  public KudosTemplateBuilder(TemplateProvider templateProvider, boolean pushNotification) {
+  private XMLProcessor     xmlProcessor;
+
+  public KudosTemplateBuilder(TemplateProvider templateProvider, boolean pushNotification , XMLProcessor xmlProcessor) {
     this.templateProvider = templateProvider;
     this.pushNotification = pushNotification;
+    this.xmlProcessor = xmlProcessor;
   }
 
   @Override
@@ -93,10 +98,11 @@ public class KudosTemplateBuilder extends AbstractTemplateBuilder {
                                                                            : LinkProvider.PROFILE_DEFAULT_AVATAR_URL);
     templateContext.put("KUDOS_ID", notification.getValueOwnerParameter("KUDOS_ID"));
     String message = notification.getValueOwnerParameter("KUDOS_MESSAGE");
+    message = (String)xmlProcessor.process(message);
     if (StringUtils.isBlank(message)) {
       message = "";
     }
-    templateContext.put("KUDOS_MESSAGE", StringEscapeUtils.escapeHtml(message));
+    templateContext.put("KUDOS_MESSAGE", message);
     String title = "";
     String notificationURL = CommonsUtils.getCurrentDomain();
 

--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/MailTemplateProvider.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/MailTemplateProvider.java
@@ -24,13 +24,17 @@ import org.exoplatform.commons.api.notification.channel.template.TemplateProvide
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.kudos.notification.builder.KudosTemplateBuilder;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 
 @TemplateConfigs(templates = {
     @TemplateConfig(pluginId = KUDOS_RECEIVER_NOTIFICATION_ID, template = "war:/conf/kudos/templates/notification/mail/KudosReceiverMailPlugin.gtmpl") })
 public class MailTemplateProvider extends TemplateProvider {
 
-  public MailTemplateProvider(InitParams initParams) {
+  private XMLProcessor xmlProcessor;
+
+  public MailTemplateProvider(InitParams initParams ,XMLProcessor xmlProcessor ) {
     super(initParams);
-    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, false));
+    this.xmlProcessor = xmlProcessor;
+    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, false , this.xmlProcessor));
   }
 }

--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/MobilePushTemplateProvider.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/MobilePushTemplateProvider.java
@@ -24,14 +24,18 @@ import org.exoplatform.commons.api.notification.channel.template.TemplateProvide
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.kudos.notification.builder.KudosTemplateBuilder;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 
 @TemplateConfigs(templates = {
     @TemplateConfig(pluginId = KUDOS_RECEIVER_NOTIFICATION_ID, template = "war:/conf/kudos/templates/notification/push/KudosReceiverPushPlugin.gtmpl") })
 public class MobilePushTemplateProvider extends TemplateProvider {
 
-  public MobilePushTemplateProvider(InitParams initParams) {
+  private XMLProcessor xmlProcessor;
+
+  public MobilePushTemplateProvider(InitParams initParams , XMLProcessor xmlProcessor) {
     super(initParams);
-    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, true));
+    this.xmlProcessor = xmlProcessor;
+    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, true , this.xmlProcessor));
   }
 
 }

--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/WebTemplateProvider.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/provider/WebTemplateProvider.java
@@ -24,14 +24,18 @@ import org.exoplatform.commons.api.notification.channel.template.TemplateProvide
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.kudos.notification.builder.KudosTemplateBuilder;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 
 @TemplateConfigs(templates = {
     @TemplateConfig(pluginId = KUDOS_RECEIVER_NOTIFICATION_ID, template = "war:/conf/kudos/templates/notification/web/KudosReceiverWebPlugin.gtmpl") })
 public class WebTemplateProvider extends TemplateProvider {
 
-  public WebTemplateProvider(InitParams initParams) {
+  private XMLProcessor xmlProcessor;
+
+  public WebTemplateProvider(InitParams initParams , XMLProcessor xmlProcessor) {
     super(initParams);
-    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, false));
+    this.xmlProcessor = xmlProcessor;
+    this.templateBuilders.put(PluginKey.key(KUDOS_RECEIVER_NOTIFICATION_ID), new KudosTemplateBuilder(this, false,this.xmlProcessor));
   }
 
 }

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/web/KudosReceiverWebPlugin.gtmpl
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/web/KudosReceiverWebPlugin.gtmpl
@@ -36,9 +36,8 @@
         <% } %>
         <% if(org.apache.commons.lang3.StringUtils.isNotBlank(KUDOS_MESSAGE)) { %>
           <div class="content">
-          <% String kudosMessage = KUDOS_MESSAGE.replaceAll("\\&lt;.+?&gt;","") %>
             <i class="uiIcon fa fa-award uiIconKudos uiIconBlue"></i>
-            <%= kudosMessage %>
+            <%= KUDOS_MESSAGE %>
           </div>
         <% } %>
         <div class="lastUpdatedTime">$LAST_UPDATED_TIME</div>


### PR DESCRIPTION
Before this fix , kudos mail and push notfication message is displayed with tags , so i refactored the template builder and the corresponding gtmpl templates so that the message is displayed formatted for mail notification and without tags for push notofication.