### PR TITLE
TASK-48989 : display kudos number for activity in reaction drawer

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/ActivityKudosReactionList.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/ActivityKudosReactionList.vue
@@ -26,7 +26,7 @@ export default {
   },
   methods: {
     retrieveKudos() {
-      return this.$kudosService.getKudosListByActivity(this.activityId).then(data => {
+      return this.$kudosService.getEntityKudos('ACTIVITY',this.activityId).then(data => {
         this.kudosList = data;
         document.dispatchEvent(new CustomEvent('update-reaction-extension', {
           detail: {


### PR DESCRIPTION
Before this fix , kudos number refers to the total number of kudos for the activity including comments . now we will display only  the kudos number of the activity