### PR TITLE
Task-51620 : Add aria-label on kudos drawer buttons (#131)

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -110,11 +110,13 @@
         <div class="d-flex justify-end">
           <v-btn
             class="btn me-2"
+            :aria-label="$t('Confirmation.label.Cancel')"
             @click="$refs.activityKudosDrawer.close()">
             {{ $t('Confirmation.label.Cancel') }}
           </v-btn>
           <v-btn
             :disabled="sendButtonDisabled"
+            :aria-label="$t('exoplatform.kudos.button.send')"
             class="btn btn-primary me-2"
             @click="send">
             {{ $t('exoplatform.kudos.button.send') }}


### PR DESCRIPTION
Before this fix, the kudos drawer button does not respect RGAA Criteria 11.9 :
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-9
This commit add the aria-label attribute on theses button to make it compliant