### PR TITLE
TASK-52913 : kudos icon always blue when number of possible kudos sent is more than 3

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -58,7 +58,6 @@
               <div
                 v-if="kudosSent || remainingKudos"
                 class="flex d-flex justify-end pt-15">
-                <div v-if="numberOfKudosAllowed <= numberOfKudosToDisplay">
                   <v-icon
                     v-for="index in remainingKudos"
                     :key="index"
@@ -73,16 +72,6 @@
                     size="20">
                     fa-award
                   </v-icon>
-                </div>
-                <div v-else>
-                  <v-icon
-                    v-for="index in numberOfKudosToDisplay"
-                    :key="index"
-                    class="uiIconKudos uiIconBlue pl-1"
-                    size="20">
-                    fa-award
-                  </v-icon>
-                </div>
               </div>
             </div>
             <div class="d-flex flex-row pt-5">
@@ -136,7 +125,6 @@ export default {
   data() {
     return {
       numberOfKudosAllowed: 0,
-      numberOfKudosToDisplay: 3,
       listDialog: false,
       ignoreRefresh: false,
       kudosList: false,


### PR DESCRIPTION
Before this fix : go to administration->kudos and change the allowed kudos per user and choose a value greater than 3 (4 for example), and try to send a kudos from a such space's new post, the kudos drawer will display contains 4 blue kudos icons and even after sending some kudos the colors are never changed to a grey ones, so it's not logical behavior.
I've noticed that there is static value used to compare with the use's numberOfKudosAllowed=3 which could be modified by the administration.

After this fix : remove every usage of the static value 'numberOfKudosToDisplay' and use the numberOfKudosAllowed which gets the right number of allowed kudos changed by the admin, with thses changes i could have the right display of kudos icons with the appropriate color whatever the kudos allowed number is.