### PR TITLE
Task-53256: added a title to kudos push notification containing who sent the kudos #148 (#152)

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/push/KudosReceiverPushPlugin.gtmpl
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/templates/notification/push/KudosReceiverPushPlugin.gtmpl
@@ -6,4 +6,5 @@
     message = _ctx.appRes("Notification.kudos.received", USER);
   }
 %>
+<%= message%>
 $KUDOS_MESSAGE


### PR DESCRIPTION
ISSUE: the push notifications for kudos contain only the message sent by the user
FIX: added a title to the kudos push notification to inform the user of who sent the kudos