### PR TITLE
Task-56691 : Fix display of Kudos button tooltip on top of Activity Comment Drawer in Mobile

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -4,10 +4,7 @@
     class="d-inline-flex">
     <v-tooltip bottom>
       <template #activator="{ on, attrs }">
-        <div
-          class="d-flex"
-          v-bind="attrs"
-          v-on="on">
+        <div class="d-flex">
           <v-btn
             :id="`KudosActivity${entityId}`"
             :disabled="buttonDisabled"
@@ -17,7 +14,9 @@
             class="pa-0 mt-0"
             text
             link
-            @click="openKudosForm">
+            @click="openKudosForm"
+            v-bind="attrs"
+            v-on="on">
             <template v-if="isComment">
               {{ $t('exoplatform.kudos.label.kudos') }}
             </template>


### PR DESCRIPTION
problem: Kudos button tooltip  displayed on the drawer footer for mobile devices
fix: changed the placement of vuetify properties so that the tooltip works correctly and doesn't display when w open the drawer