### PR TITLE
TASK:56691: disable v-tooltip for mobile devices

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -2,12 +2,9 @@
   <div
     :class="!isComment && 'ms-lg-4'"
     class="d-inline-flex">
-    <v-tooltip 
-    v-model="show"
-    bottom>
-      <template #activator="{ on, attrs }">
         <div class="d-flex">
           <v-btn
+            :title="buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos')"
             :id="`KudosActivity${entityId}`"
             :disabled="buttonDisabled"
             :class="textColorClass"
@@ -37,14 +34,8 @@
             </template>
           </v-btn>
         </div>
-      </template>
-      <span>
-        {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
-      </span>
-    </v-tooltip>
-    <v-tooltip bottom>
-      <template #activator="{ on, attrs }">
         <v-btn
+          :title="$t('exoplatform.kudos.button.displayKudosList')"
           v-show="kudosCount"
           :id="`KudusCountLink${commentId}`"
           :small="!isComment"
@@ -56,11 +47,6 @@
           @click="openKudosList">
           ({{ kudosCount }})
         </v-btn>
-      </template>
-      <span>
-        {{ $t('exoplatform.kudos.button.displayKudosList') }}
-      </span>
-    </v-tooltip>
   </div>
 </template>
 
@@ -79,7 +65,6 @@ export default {
   data: () => ({
     linkedKudosList: [],
     limit: 100,
-    show: false,
   }),
   computed: {
     entityType() {
@@ -158,7 +143,6 @@ export default {
       }
     },
     openKudosForm(event) {
-      this.show = false;
       if (event) {
         event.preventDefault();
         event.stopPropagation();

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -2,9 +2,12 @@
   <div
     :class="!isComment && 'ms-lg-4'"
     class="d-inline-flex">
+    <v-tooltip 
+    v-model="show"
+    bottom>
+      <template #activator="{ on, attrs }">
         <div class="d-flex">
           <v-btn
-            :title="buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos')"
             :id="`KudosActivity${entityId}`"
             :disabled="buttonDisabled"
             :class="textColorClass"
@@ -34,8 +37,14 @@
             </template>
           </v-btn>
         </div>
+      </template>
+      <span>
+        {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
+      </span>
+    </v-tooltip>
+    <v-tooltip bottom>
+      <template #activator="{ on, attrs }">
         <v-btn
-          :title="$t('exoplatform.kudos.button.displayKudosList')"
           v-show="kudosCount"
           :id="`KudusCountLink${commentId}`"
           :small="!isComment"
@@ -47,6 +56,11 @@
           @click="openKudosList">
           ({{ kudosCount }})
         </v-btn>
+      </template>
+      <span>
+        {{ $t('exoplatform.kudos.button.displayKudosList') }}
+      </span>
+    </v-tooltip>
   </div>
 </template>
 
@@ -65,6 +79,7 @@ export default {
   data: () => ({
     linkedKudosList: [],
     limit: 100,
+    show: false,
   }),
   computed: {
     entityType() {
@@ -143,6 +158,7 @@ export default {
       }
     },
     openKudosForm(event) {
+      this.show = false;
       if (event) {
         event.preventDefault();
         event.stopPropagation();

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -3,8 +3,8 @@
     :class="!isComment && 'ms-lg-4'"
     class="d-inline-flex">
     <v-tooltip 
-    v-model="show"
-    bottom>
+      :disabled="isMobile"
+      bottom>
       <template #activator="{ on, attrs }">
         <div class="d-flex">
           <v-btn
@@ -42,7 +42,9 @@
         {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
       </span>
     </v-tooltip>
-    <v-tooltip bottom>
+    <v-tooltip 
+    :disabled="isMobile"
+    bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-show="kudosCount"
@@ -125,6 +127,9 @@ export default {
       }
       return false;
     },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
+    },
   },
   created() {
     this.$root.$on('activity-comment-created', this.resetActivity);
@@ -158,7 +163,6 @@ export default {
       }
     },
     openKudosForm(event) {
-      this.show = false;
       if (event) {
         event.preventDefault();
         event.stopPropagation();

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -2,9 +2,7 @@
   <div
     :class="!isComment && 'ms-lg-4'"
     class="d-inline-flex">
-    <v-tooltip 
-      :disabled="isMobile"
-      bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <div class="d-flex">
           <v-btn
@@ -42,9 +40,7 @@
         {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
       </span>
     </v-tooltip>
-    <v-tooltip 
-    :disabled="isMobile"
-    bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-show="kudosCount"


### PR DESCRIPTION
ISSUE: v-tooltip is not compatibale with the safari browser, the tooltip message stays displayed after the component is closed
FIX: disable the v-tooltip component for mobile devices