### PR TITLE
TASK:56691: disable v-tooltip for mobile devices

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -2,7 +2,7 @@
   <div
     :class="!isComment && 'ms-lg-4'"
     class="d-inline-flex">
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <div
           class="d-flex"
@@ -41,7 +41,7 @@
         {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
       </span>
     </v-tooltip>
-    <v-tooltip bottom>
+    <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
         <v-btn
           v-show="kudosCount"
@@ -122,6 +122,9 @@ export default {
         return activityOwnerId === eXo.env.portal.userIdentityId;
       }
       return false;
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'xs';
     },
   },
   created() {


### PR DESCRIPTION
ISSUE: v-tooltip is not compatibale with the safari browser, the tooltip message stays displayed after the component is closed
FIX: disable the v-tooltip component for mobile devices