### PR TITLE
Task-178: kudos counter  (mobile view)

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -202,6 +202,11 @@ export function registerActivityReactionTabs() {
     vueComponent: Vue.options.components['activity-kudos-reaction-list'],
     rank: 2,
   });
+  extensionRegistry.registerComponent('ActivityReactionsCount', 'activity-reaction-count', {
+    id: 'kudos',
+    vueComponent: Vue.options.components['activity-kudos-reaction-count'],
+    rank: 1,
+  });
 }
 
 export function registerActivityActionExtension() {

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/ActivityKudosReactionCount.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/ActivityKudosReactionCount.vue
@@ -1,0 +1,42 @@
+<template>
+  <a
+    v-if="kudosNumber>0"
+    class="my-1 me-2 KudosNumber"
+    @click="openKudosList">
+    {{ kudosNumber }} Kudos</a>
+</template>
+
+<script>
+export default {
+  props: {
+    activity: {
+      type: Object,
+      default: null,
+    },
+  },
+  data: () => ({
+    kudosNumber: 0,
+  }),
+  created() {
+    this.$root.$on('kudos-refresh-comment', this.getKudosCount);
+    this.getKudosCount();
+  },
+  methods: {
+    getKudosCount() {
+      return this.$kudosService.computeActivityKudosList(this.activity)
+        .then(() => this.kudosNumber = this.activity.linkedKudosList.length || 0);
+    },
+    openKudosList(event) {
+      if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      document.dispatchEvent(new CustomEvent(`open-reaction-drawer-selected-tab-${this.activity.id}`, {detail: {
+        activityId: this.activity.id,
+        tab: 'kudos',
+        activityType: 'ACTIVITY'
+      }}));
+    },
+  }
+};
+</script>

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -48,7 +48,7 @@
           :id="`KudusCountLink${commentId}`"
           :small="!isComment"
           :x-small="isComment"
-          class="primary--text font-weight-bold baseline-vertical-align mt-0"
+          class="primary--text font-weight-bold baseline-vertical-align mt-0 d-none d-lg-block"
           icon
           v-bind="attrs"
           v-on="on"

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/initComponents.js
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/initComponents.js
@@ -9,6 +9,7 @@ import ActivityKudosReactionList from './components/ActivityKudosReactionList.vu
 import ActivityKudosReactionEmptyList from './components/common/ActivityKudosReactionEmptyList.vue';
 import KudosOverviewDrawer from './components/common/KudosOverviewDrawer.vue';
 import KudosOverviewItem from './components/common/KudosOverviewItem.vue';
+import ActivityKudosReactionCount from './components/ActivityKudosReactionCount.vue';
 
 const components = {
   'kudos-api': KudosAPI,
@@ -22,6 +23,7 @@ const components = {
   'activity-kudos-reaction-empty-list': ActivityKudosReactionEmptyList,
   'kudos-overview-drawer': KudosOverviewDrawer,
   'kudos-overview-item': KudosOverviewItem,
+  'activity-kudos-reaction-count': ActivityKudosReactionCount
 };
 
 for (const key in components) {


### PR DESCRIPTION
Prior to this change, the kudos count in the mobile view was displayed right next to the kudos icon.
This PR will update the display of the number of kudos, so it will have the same behavior as the comments and the likes in the mobile view.