### PR TITLE
BUILDERS-189: Send a kudos to someone different from the activity's author

### DIFF
--- a/kudos-webapps/src/main/webapp/css/main.less
+++ b/kudos-webapps/src/main/webapp/css/main.less
@@ -159,6 +159,9 @@
   .clickable {
     cursor: pointer;
   }
+  .outlined {
+    border: 1px solid @borderColor;
+  }
 }
 
 .uiIconKudos.uiIconLightGrey {

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -101,6 +101,9 @@ export default {
     isComment() {
       return !!this.comment;
     },
+    spaceURL() {
+      return this.activity && this.activity.activityStream && this.activity.activityStream.space && this.activity.activityStream.space.prettyName;
+    },
     kudosCount() {
       return this.linkedKudosList.length;
     },
@@ -168,6 +171,7 @@ export default {
         parentId: this.parentId,
         type: this.entityType,
         owner: this.entityOwner,
+        spaceURL: this.spaceURL
       }}));
     },
     openKudosList(event) {


### PR DESCRIPTION
Prior this change, the user cannot change the default kudos receiver when trying to send kudos from an activity or comment.
Add the possibility to change the receiver by another user who is a member of the space in which the activity is posted.