### PR TITLE
BUILDERS-214: Browser tab's name is wrong for a kudos activity

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -258,7 +258,7 @@ export function registerActivityActionExtension() {
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: receiverIdentity
+              0: receiverIdentity.fullname
             },
           };
         }


### PR DESCRIPTION
Prior this change, when user open a kudos activity,the tab shows a wrong label for the kudos receiver