### PR TITLE
BUILDERS-214: Browser tab's name is wrong for a kudos activity

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -269,7 +269,7 @@ export function registerActivityActionExtension() {
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/"/g, "'")}">${kudos.receiverFullName}</a>`
+              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/"/g, '\'')}">${kudos.receiverFullName}</a>`
             },
           };
         }

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -258,10 +258,18 @@ export function registerActivityActionExtension() {
       getTitle: activityOrComment => {
         const kudos = activityOrComment && activityOrComment.kudos;
         if (kudos) {
+          const receiverIdentity = {
+            'id': kudos.receiverIdentityId,
+            'username': kudos.receiverId,
+            'fullName': kudos.receiverFullName,
+            'avatar': kudos.receiverAvatar,
+            'position': kudos.receiverPosition,
+            'external': String(kudos.externalReceiver),
+          };
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: kudos.receiverFullName
+              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/"/g, "'")}">${kudos.receiverFullName}</a>`
             },
           };
         }

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -246,15 +246,6 @@ export function registerActivityActionExtension() {
       },
       getSourceLink: () => '#',
       getActivityType: () => 'kudos',
-      getReceiver: activityOrComment =>{
-        const kudos = activityOrComment && activityOrComment.kudos;
-        return {
-          'username': kudos.receiverId,
-          'fullname': kudos.receiverFullName,
-          'position': kudos.receiverPosition,
-          'external': kudos.externalReceiver,
-        };
-      },
       getTitle: activityOrComment => {
         const kudos = activityOrComment && activityOrComment.kudos;
         if (kudos) {

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -246,19 +246,22 @@ export function registerActivityActionExtension() {
       },
       getSourceLink: () => '#',
       getActivityType: () => 'kudos',
+      getReceiver: activityOrComment =>{
+        const kudos = activityOrComment && activityOrComment.kudos;
+        return {
+          'username': kudos.receiverId,
+          'fullname': kudos.receiverFullName,
+          'position': kudos.receiverPosition,
+          'external': kudos.externalReceiver,
+        };
+      },
       getTitle: activityOrComment => {
         const kudos = activityOrComment && activityOrComment.kudos;
         if (kudos) {
-          const receiverIdentity = {
-            'username': kudos.receiverId,
-            'fullname': kudos.receiverFullName,
-            'position': kudos.receiverPosition,
-            'external': kudos.externalReceiver,
-          };
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: receiverIdentity.fullname
+              0: kudos.receiverFullName
             },
           };
         }


### PR DESCRIPTION
Prior this change, when user open a kudos activity,the tab shows a wrong label for the kudos receiver