### PR TITLE
MEED-214: Browser tab's name is wrong for a kudos activity

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -250,15 +250,17 @@ export function registerActivityActionExtension() {
         const kudos = activityOrComment && activityOrComment.kudos;
         if (kudos) {
           const receiverIdentity = {
+            'id': kudos.receiverIdentityId,
             'username': kudos.receiverId,
-            'fullname': kudos.receiverFullName,
+            'fullName': kudos.receiverFullName,
+            'avatar': kudos.receiverAvatar,
             'position': kudos.receiverPosition,
-            'external': kudos.externalReceiver,
+            'external': String(kudos.externalReceiver),
           };
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: receiverIdentity
+              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/"/g, '\'')}">${kudos.receiverFullName}</a>`
             },
           };
         }


### PR DESCRIPTION
Prior this change, when user open a kudos activity,the tab shows a wrong label for the kudos receiver
Update:
+ Fix tab label
+ Use v-identity-popover