### PR TITLE
MEED-269: Bad display in kudos TAB when no Kudos is sent yet

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/ActivityKudosReactionEmptyList.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/ActivityKudosReactionEmptyList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="no-kudos-block flex flex-column align-center text-sub-title pt-12">
+  <div class="no-kudos-block flex d-flex flex-column align-center text-sub-title pt-12">
     <v-icon
       class="text-sub-title"
       size="64">


### PR DESCRIPTION
Prior this change, The kudos icon and the text are not displayed as expected in kudos tab when no kudos send yet