### PR TITLE
MEED-297 Fix display of popover when user position has a apostrophe

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -260,7 +260,7 @@ export function registerActivityActionExtension() {
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {
-              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/"/g, '\'')}">${kudos.receiverFullName}</a>`
+              0: `<a href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${kudos.receiverId}" v-identity-popover="${JSON.stringify(receiverIdentity).replace(/'/g, '\\\'').replace(/"/g, '\'')}">${kudos.receiverFullName}</a>`
             },
           };
         }


### PR DESCRIPTION
Prior to this change, when displaying a user having apostrophe in position field, the kudos activity title is hidden. This fix ensures to escape apostrophe character to build the correct value of HTML user profile link with popover.