### PR TITLE
Task-48748: Disable kudos for disabled users

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -38,7 +38,7 @@
         </div>
       </template>
       <span>
-        {{ buttonDisabled && $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') || $t('exoplatform.kudos.title.sendAKudos') }}
+            {{ buttonDisabled === 'same' ? $t('exoplatform.kudos.info.onlyOtherCanSendYouKudos') : $t('exoplatform.kudos.title.sendAKudos') }}
       </span>
     </v-tooltip>
     <v-tooltip :disabled="isMobile" bottom>
@@ -113,13 +113,30 @@ export default {
     textColorClass() {
       return this.hasSentKudos && 'primary--text' || '';
     },
+    inactiveCommentOwner() {
+      return !this.comment.identity.profile.dataEntity.enabled || this.comment.identity.deleted;
+    },
+    inactiveActivityOwner() {
+      return  !this.activity.identity.profile.dataEntity.enabled || this.activity.identity.deleted;
+    },   
+    userIdentityId() {
+      return  eXo.env.portal.userIdentityId;
+    },                           
     buttonDisabled() {
       if (this.comment) {
-        const commentOwnerId = this.comment.identity && this.comment.identity.id;
-        return commentOwnerId === eXo.env.portal.userIdentityId;
+        const commentOwnerId = this.comment.identity && this.comment.identity.id; 
+        if (commentOwnerId === this.userIdentityId) {
+          return 'same'; 
+        } else if (this.inactiveCommentOwner){
+          return 'inactive';        
+        }        
       } else if (this.activity) {
-        const activityOwnerId = this.activity.identity && this.activity.identity.id;
-        return activityOwnerId === eXo.env.portal.userIdentityId;
+        const activityOwnerId = this.activity.identity && this.activity.identity.id; 
+        if (activityOwnerId === this.userIdentityId){
+          return 'same';
+        } else if (this.inactiveActivityOwner){
+          return 'inactive';        
+        }        
       }
       return false;
     },

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/PopoverKudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/PopoverKudosButton.vue
@@ -4,6 +4,7 @@
       <div
         v-bind="attrs"
         v-on="on">
+         <div v-if="identityEnabled && !identityDeleted">  
         <v-btn
           :ripple="false"
           icon
@@ -11,6 +12,7 @@
           @click="sendKudos($event)">
           <v-icon size="18">fas fa-award</v-icon>
         </v-btn>
+      </div>
       </div>
     </template>
     <span>
@@ -29,7 +31,15 @@ export default {
       type: String,
       default: ''
     },
-  },
+    identityEnabled: {
+      type: String,
+      default: '',
+    },  
+    identityDeleted: {
+      type: String,
+      default: ''
+    },     
+  },  
   methods: {
     sendKudos(event) {
       event.preventDefault();


### PR DESCRIPTION
prior to this change it was possible to try to send kudos to disabled users fix:
1) update on buttonDisabled to check if receiver's identity is enabled so if its value is false the action button on comments and activities would be disabled 2) display/not display kudos icon for users popover

(cherry picked from commit f57c7268ea55e6db4986745975cec2a38a63d1b7)