### PR TITLE
fix : In reward administration, the request to compute reward is too long - EXO-60157 - meeds-io/meeds#330

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/dao/KudosDAO.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/dao/KudosDAO.java
@@ -2,8 +2,11 @@ package org.exoplatform.kudos.dao;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.persistence.NoResultException;
+import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
@@ -73,6 +76,13 @@ public class KudosDAO extends GenericDAOJPAImpl<KudosEntity, Long> {
     query.setParameter("isReceiverUser", isReceiverUser);
     Long count = query.getSingleResult();
     return count == null ? 0 : count;
+  }
+
+  public Map<Long, Long> countKudosByPeriodAndReceivers(KudosPeriod kudosPeriod, List<Long> receiversId) {
+    TypedQuery<Tuple> query = getEntityManager().createNamedQuery("Kudos.countKudosByPeriodAndReceivers", Tuple.class);
+    setPeriodParameters(query, kudosPeriod);
+    query.setParameter("receiversId", receiversId);
+    return query.getResultList().stream().collect(Collectors.toMap(tuple -> (Long) tuple.get(0), tuple -> (Long) tuple.get(1)));
   }
 
   public List<KudosEntity> getKudosByPeriodAndSender(KudosPeriod kudosPeriod, long senderId, int limit) {

--- a/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
@@ -47,7 +47,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " WHERE k.receiverId = :receiverId"
         + " AND k.isReceiverUser = :isReceiverUser" + " AND k.createdDate > :startDate" + " AND k.createdDate < :endDate"),
     @NamedQuery(name = "Kudos.countKudosByPeriodAndReceivers", query = "select k.receiverId,count(k) from Kudos k"
-        + " WHERE k.receiverId IN :receiversId" + " AND k.createdDate > :startDate"
+        + " WHERE k.receiverId IN :receiversId" + " AND k.createdDate >= :startDate"
         + " AND k.createdDate < :endDate GROUP BY k.receiverId") })
 public class KudosEntity implements Serializable {
 

--- a/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
@@ -45,7 +45,10 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " ORDER BY k.createdDate DESC"),
     @NamedQuery(name = "Kudos.countKudosByPeriodAndReceiver", query = "select count(k) from Kudos k"
         + " WHERE k.receiverId = :receiverId"
-        + " AND k.isReceiverUser = :isReceiverUser" + " AND k.createdDate > :startDate" + " AND k.createdDate < :endDate") })
+        + " AND k.isReceiverUser = :isReceiverUser" + " AND k.createdDate > :startDate" + " AND k.createdDate < :endDate"),
+    @NamedQuery(name = "Kudos.countKudosByPeriodAndReceivers", query = "select k.receiverId,count(k) from Kudos k"
+        + " WHERE k.receiverId IN :receiversId" + " AND k.createdDate > :startDate"
+        + " AND k.createdDate < :endDate GROUP BY k.receiverId") })
 public class KudosEntity implements Serializable {
 
   private static final long serialVersionUID = -8272292325540761902L;

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
@@ -401,6 +401,19 @@ public class KudosService implements ExoKudosStatisticService, Startable {
   }
 
   /**
+   * Count kudos received by a list of identities in a period of time
+   *
+   * @param identitiesId {@link Identity} List of technical id
+   * @param startDateInSeconds timestamp in seconds
+   * @param endDateInSeconds timestamp in seconds
+   * @return Map<identityId,kudoCount> the number of kudos by identity
+   */
+  public Map<Long, Long> countKudosByPeriodAndReceivers(List<Long> identitiesId, long startDateInSeconds, long endDateInSeconds) {
+    KudosPeriod kudosPeriod = new KudosPeriod(startDateInSeconds, endDateInSeconds);
+    return kudosStorage.countKudosByPeriodAndReceivers(kudosPeriod, identitiesId);
+  }
+
+  /**
    * Retrieves kudos received by an identity in a period of time
    * 
    * @param identityId {@link Identity} technical id

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosStorage.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosStorage.java
@@ -110,6 +110,10 @@ public class KudosStorage {
                                                   isReceiverUser);
   }
 
+  public Map<Long, Long> countKudosByPeriodAndReceivers(KudosPeriod kudosPeriod, List<Long> receiversId) {
+    return kudosDAO.countKudosByPeriodAndReceivers(kudosPeriod, receiversId);
+  }
+
   public List<Kudos> getKudosByPeriodAndReceiver(KudosPeriod kudosPeriod, String receiverType, String receiverId, int limit) {
     boolean isReceiverUser = USER_ACCOUNT_TYPE.equals(receiverType) || OrganizationIdentityProvider.NAME.equals(receiverType);
     long identityId = getIdentityId(receiverId, isReceiverUser);

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/dao/KudosDAOTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/dao/KudosDAOTest.java
@@ -4,7 +4,9 @@ import static org.exoplatform.kudos.service.utils.Utils.fromEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -122,6 +124,27 @@ public class KudosDAOTest extends BaseKudosTest {
 
     count = kudosDAO.countKudosByPeriodAndReceiver(kudosPeriod, 30, true);
     assertEquals(0, count);
+  }
+
+  @Test
+  public void testCountKudosByPeriodAndReceivers() {
+
+    KudosDAO kudosDAO = getService(KudosDAO.class);
+    KudosPeriod kudosPeriod = new KudosPeriod(getTime(2019, 1, 1), getCurrentTimeInSeconds());
+
+    List<Long> receiversId = new ArrayList<>();
+    receiversId.add(receiverId);
+
+    Map<Long, Long> counts = kudosDAO.countKudosByPeriodAndReceivers(kudosPeriod, receiversId);
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(counts.get(receiverId)).orElse(0L));
+
+    newKudos();
+
+    receiversId.add(30L);
+
+    counts = kudosDAO.countKudosByPeriodAndReceivers(kudosPeriod, receiversId);
+    assertEquals(Long.valueOf(1), java.util.Optional.ofNullable(counts.get(receiverId)).orElse(0L));
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(counts.get(30L)).orElse(0L));
   }
 
   @Test

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
@@ -2,10 +2,13 @@ package org.exoplatform.kudos.test.service;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.regexp.RE;
 import org.junit.Test;
 
 import org.exoplatform.kudos.entity.KudosEntity;
@@ -151,6 +154,30 @@ public class KudosServiceTest extends BaseKudosTest {
 
     count = kudosService.countKudosByPeriodAndReceiver(30000, startTime, endTime);
     assertEquals(0, count);
+  }
+
+  @Test
+  public void testCountKudosByPeriodAndReceivers() {
+
+    KudosService kudosService = getService(KudosService.class);
+    long startTime = getTime(2019, 1, 1);
+    long endTime = getCurrentTimeInSeconds();
+
+    List<Long> receivers = new ArrayList<>();
+    receivers.add(RECEIVER_ID);
+
+    Map<Long, Long> counts = kudosService.countKudosByPeriodAndReceivers(receivers, startTime, endTime);
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(counts.get(RECEIVER_ID)).orElse(0L));
+
+    newKudos();
+
+    receivers.add(30L);
+    receivers.add(30000L);
+
+    counts = kudosService.countKudosByPeriodAndReceivers(receivers, startTime, endTime);
+    assertEquals(Long.valueOf(1), java.util.Optional.ofNullable(counts.get(RECEIVER_ID)).orElse(0L));
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(counts.get(30L)).orElse(0L));
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(counts.get(30000L)).orElse(0L));
   }
 
   @Test


### PR DESCRIPTION
Before this fix, with a lot of line in gamification history table, the request time for the "compute" request exceed the nginx timeout. This is due to the fact that scores are computed users by users. So there are 1 database request by reward plugin and by user. On tribe, 2*148 request. Each databse requests execute in near 800ms, so the request execution time is too long. This fix add change the compute to have one request per reward plugin, compute score for all users.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
