### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#336

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -18,7 +18,7 @@
      </init-param>
      <init-param>
        <name>preload.resource.rest</name>
-       <value><![CDATA[/portal/rest/kudos/api/account/settings,/portal/rest/kudos/api/settings,/portal/rest/kudos/api/kudos/{userId}/sent?limit=300&returnSize=true&periodType=&dateInSeconds=0]]></value>
+       <value><![CDATA[/portal/rest/kudos/api/account/settings,/portal/rest/kudos/api/settings,/portal/rest/kudos/api/kudos/{userId}/sent?limit=20&returnSize=true&periodType=&dateInSeconds=0]]></value>
      </init-param>
      <expiration-cache>-1</expiration-cache>
      <cache-scope>PUBLIC</cache-scope>


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase
this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page