### PR TITLE
fix : Activity Stream some pre-fetched REST URLs aren't used in page - MEED-645 - Meeds-io/meeds#336

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -18,7 +18,7 @@
      </init-param>
      <init-param>
        <name>preload.resource.rest</name>
-       <value><![CDATA[/portal/rest/kudos/api/account/settings,/portal/rest/kudos/api/settings,/portal/rest/kudos/api/kudos/{userId}/sent?limit=300&returnSize=true&periodType=&dateInSeconds=0]]></value>
+       <value><![CDATA[/portal/rest/kudos/api/account/settings,/portal/rest/kudos/api/settings,/portal/rest/kudos/api/kudos/{userId}/sent?limit=20&returnSize=true&periodType=&dateInSeconds=0]]></value>
      </init-param>
      <expiration-cache>-1</expiration-cache>
      <cache-scope>PUBLIC</cache-scope>


### PR DESCRIPTION
Prior to change some social activities URLs are prefetched while it's not used immediately in page rendering phase this change is going to inhance performance by prefetch only necessary URLs used for the first rendering of the page

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
