### PR TITLE
feat: Overview Page Implement blank kudos in my reputation portlet - MEED-666 - Meeds-io/MIPs#10

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -195,7 +195,7 @@ export function registerExternalExtensions(title) {
 }
 
 export function registerOverviewExtension() {
-  extensionRegistry.registerComponent('my-reputation-overview', 'my-reputation-item', {
+  extensionRegistry.registerComponent('my-reputation-overview-kudos', 'my-reputation-item', {
     id: 'kudos-reputation-overview',
     vueComponent: Vue.options.components['kudos-overview'],
     rank: 10,

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
@@ -28,7 +28,7 @@
     <v-row
       id="kudosOverviewCardsParent"
       class="white border-box-sizing px-4 py-0 ma-0 align-center" 
-      :style="isOverviewDisplay && 'min-height:66px;'">
+      :style="isOverviewDisplay && 'min-height:55px;'">
       <v-col class="kudosOverviewCard">
         <kudos-overview-card
           :is-overview-display="isOverviewDisplay"
@@ -146,6 +146,7 @@ export default {
           this.$root.$emit('application-loaded');
           // Decrement 'loading' effect in top of the page
           document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
+          document.dispatchEvent(new CustomEvent('kudosCount', {detail: this.sentKudosCount + this.receivedKudosCount}));
         });
     },
   },


### PR DESCRIPTION
this change is going to adapt the kudos display according the design to be properly implemented with the case when we have no data, In addition to this, the my reputation extension registry has been sliced into two extensions to be handled each with its use cases
