### PR TITLE
fix: Disable send kudos from an activity for user who has left the space - EXO-61097 (#252)

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -130,14 +130,14 @@ export default {
         const commentOwnerId = this.comment.identity && this.comment.identity.id; 
         if (commentOwnerId === this.userIdentityId) {
           return 'same'; 
-        } else if (this.inactiveCommentOwner){
+        } else if (this.inactiveCommentOwner || !this.comment.owner.isMember){
           return 'inactive';        
         }        
       } else if (this.activity) {
         const activityOwnerId = this.activity.identity && this.activity.identity.id; 
         if (activityOwnerId === this.userIdentityId){
           return 'same';
-        } else if (this.inactiveActivityOwner){
+        } else if (this.inactiveActivityOwner || !this.activity.owner.isMember){
           return 'inactive';        
         }        
       }


### PR DESCRIPTION
prior to this change, we can send to a user, who left the space, a kudos from an activity that he posted or commented after this change, sending the kudos button is disabled for those who are not member anymore