### PR TITLE
feat: Adjust Kudos sent and received to be responsively even - MEED-1387 - Meeds-io/MIPs#10 

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
@@ -10,7 +10,11 @@
       <slot name="count"></slot>
     </v-col>
     <v-col class="my-auto col-12 col-md-1 text-md-left px-0 mx-0 kudosOverviewLabel text-color">
-      <slot name="label"></slot>
+      <v-card
+        flat
+        :min-width="isOverviewDisplay ? '55' : '113'">
+        <slot name="label"></slot>
+      </v-card>
     </v-col>
   </v-row>
 </template>


### PR DESCRIPTION
`prior to this change`, the kudos sent and received are `mismatching` while screen `resolution` is changing to revoke this [display](https://community.exoplatform.com/portal/rest/jcr/repository/collaboration/Groups/spaces/meeds_labers/Documents/product/engagement%20ft/test%20report/Selection_363.png?time=1671629055896) 
`This change` is going to to fix this display by fixing the width of labels the behave evenly inorder to achieve [this state](https://community.exoplatform.com/portal/rest/jcr/repository/collaboration/Groups/spaces/meeds_labers/Documents/product/engagement%20ft/test%20report/overview%20-%20kudos%20mobile%20view.png?time=1671629197681)