### PR TITLE
feat: Adjust Kudos sent and received to be responsively even - MEED-1387 - Meeds-io/MIPs#10

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
@@ -3,10 +3,10 @@
     :class="clickable && 'clickable' || ''"
     class="border-box-sizing text-center justify-center"
     @click="clickable && $emit('open-drawer')">
-    <v-col class="my-auto px-0 col-md-3 kudosOverviewIcon pa-0 py-auto">
+    <v-col class="my-auto px-0 col-md-3 kudosOverviewIcon pa-0">
       <v-icon class="tertiary-color uiIconAward" :size="isOverviewDisplay ? '40' : '56'" />
     </v-col>
-    <v-col class="my-auto col-md-2 kudosOverviewCount text-color mx-0 display-1 font-weight-bold pa-0 py-auto">
+    <v-col class="my-auto col-md-2 kudosOverviewCount text-color mx-0 display-1 font-weight-bold pa-0">
       <slot name="count"></slot>
     </v-col>
     <v-col class="my-auto col-12 col-md-1 text-md-left px-0 mx-0 kudosOverviewLabel text-color">

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
@@ -3,16 +3,16 @@
     :class="clickable && 'clickable' || ''"
     class="border-box-sizing text-center justify-center"
     @click="clickable && $emit('open-drawer')">
-    <v-col class="my-auto px-0 col-md-3 kudosOverviewIcon">
+    <v-col class="my-auto px-0 col-md-3 kudosOverviewIcon pa-0 py-auto">
       <v-icon class="tertiary-color uiIconAward" :size="isOverviewDisplay ? '40' : '56'" />
     </v-col>
-    <v-col class="my-auto col-md-2 kudosOverviewCount text-color mx-0 display-1 font-weight-bold">
+    <v-col class="my-auto col-md-2 kudosOverviewCount text-color mx-0 display-1 font-weight-bold pa-0 py-auto">
       <slot name="count"></slot>
     </v-col>
     <v-col class="my-auto col-12 col-md-1 text-md-left px-0 mx-0 kudosOverviewLabel text-color">
       <v-card
         flat
-        :min-width="isOverviewDisplay ? '55' : '113'">
+        :min-width="isOverviewDisplay ? '55' : '90'">
         <slot name="label"></slot>
       </v-card>
     </v-col>


### PR DESCRIPTION
prior to this change, the kudos sent and received are mismatching while screen resolution is changing to revoke this [display](https://community.exoplatform.com/portal/rest/jcr/repository/collaboration/Groups/spaces/meeds_labers/Documents/product/engagement%20ft/test%20report/Selection_363.png?time=1671629055896)
This change is going to to fix this display by fixing the width of labels the behave evenly inorder to achieve [this state](https://community.exoplatform.com/portal/rest/jcr/repository/collaboration/Groups/spaces/meeds_labers/Documents/product/engagement%20ft/test%20report/overview%20-%20kudos%20mobile%20view.png?time=1671629197681)