### PR TITLE
feat: Fix Admin Page Margins to offer coherent UX - MEED-1320 - Meeds-io/MIPs#43

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal-configuration.xml
@@ -23,7 +23,7 @@
               <boolean>${exo.kudos.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.kudos.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.kudos.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal/group/platform/rewarding/pages.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/portal/group/platform/rewarding/pages.xml
@@ -28,14 +28,17 @@
         <title>Kudo administration</title>
         <access-permissions>*:/platform/rewarding</access-permissions>
         <edit-permission>manager:/platform/rewarding</edit-permission>
-        <portlet-application>
-            <portlet>
-                <application-ref>kudos</application-ref>
-                <portlet-ref>KudosAdmin</portlet-ref>
-            </portlet>
-            <title>Kudos administration</title>
-            <access-permissions>*:/platform/rewarding</access-permissions>
-            <show-info-bar>false</show-info-bar>
-        </portlet-application>
+        <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+          <access-permissions>*:/platform/rewarding</access-permissions>
+          <portlet-application>
+              <portlet>
+                  <application-ref>kudos</application-ref>
+                  <portlet-ref>KudosAdmin</portlet-ref>
+              </portlet>
+              <title>Kudos administration</title>
+              <access-permissions>*:/platform/rewarding</access-permissions>
+              <show-info-bar>false</show-info-bar>
+          </portlet-application>
+        </container>
     </page>
 </page-set>

--- a/kudos-webapps/src/main/webapp/css/main.less
+++ b/kudos-webapps/src/main/webapp/css/main.less
@@ -86,17 +86,19 @@
   line-height: inherit;
 }
 
-#KudosAdminApp {
-   margin: 10px 11px 0;
-}
-
-#KudosAdminApp, #KudosApp {
+#KudosApp {
   .v-autocomplete label {
     z-index: 1002;
   }
   .v-menu__content {
     z-index: 1050 !important;
   }
+  .contactAutoCompleteContent {
+    z-index: 1050 !important;
+  }
+}
+
+#KudosAdminApp, #KudosApp {
   .v-input input {
     margin-bottom: 0;
     border: 0;
@@ -108,7 +110,6 @@
     right: 0 ~'!important; /** orientation=rt */ ';
     position: absolute;
     width: 100%;
-    z-index: 1050 !important;
   }
   .contactAutoComplete {
     position: relative;

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/KudosAdmin.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/KudosAdmin.vue
@@ -1,21 +1,22 @@
 <template>
   <v-app
     id="KudosAdminApp"
-    color="transaprent"
-    class="VuetifyApp">
+    color="transaprent">
     <main>
       <v-layout>
-        <v-flex class="white text-center" flat>
+        <v-flex class="text-center" flat>
           <div v-if="error && !loading" class="alert alert-error v-content">
             <i class="uiIconError"></i>{{ error }}
           </div>
-          <v-tabs v-model="selectedTab" grow>
+          <v-tabs
+            v-model="selectedTab"
+            slider-size="4">
             <v-tabs-slider color="primary" />
             <v-tab key="general" href="#general">{{ $t('exoplatform.kudos.label.settings') }}</v-tab>
             <v-tab key="kudosList" href="#kudosList">{{ $t('exoplatform.kudos.label.kudosList') }}</v-tab>
           </v-tabs>
 
-          <v-tabs-items v-model="selectedTab">
+          <v-tabs-items v-model="selectedTab" class="mt-2">
             <v-tab-item
               id="general"
               value="general"
@@ -79,13 +80,6 @@
                       dense
                       flat
                       @update:search-input="search">
-                      <template slot="no-data">
-                        <v-list-item>
-                          <v-list-item-title>
-                            {{ $t('exoplatform.kudos.label.kudosAccessPermissionNoData') }}
-                          </v-list-item-title>
-                        </v-list-item>
-                      </template>
                       <template slot="selection" slot-scope="{ item, selected }">
                         <v-chip
                           v-if="item.error"


### PR DESCRIPTION
This change will delete inner margins of application to let the portal manage margins in a centralized way using CSS Helpers Classes. Besides, the default importMode has been changed into `MERGE` to reimport the page in old installations.