### PR TITLE
fix: Kudos fix display of success notification - MEED-1484

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -455,9 +455,7 @@ export default {
         })
         .then(() => {
           this.$refs.activityKudosDrawer.close();
-          if (this.entityType === 'COMMENT') {
-            this.displayAlert(this.$t('exoplatform.kudos.success.kudosSent'));
-          }
+          this.displayAlert(this.$t('exoplatform.kudos.success.kudosSent'));
         })
         .catch(e => {
           console.error('Error refreshing UI', e);


### PR DESCRIPTION
Prior to this change, the success notification was only shown when a kudos is sent to a comment . 
This change is going to enable the notification success to be shown when ever the kudos has been successfully sent .