### PR TITLE
feat: Improve Kudos Widget to use same display as overview page - MEED-1556 - Meeds-io/meeds#564

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/dynamic-container-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/dynamic-container-configuration.xml
@@ -61,7 +61,7 @@
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>profile-after-about-me-container</value>
+          <value>profile-right-container</value>
         </value-param>
         <object-param>
           <name>kudos-overview-portlet</name>

--- a/kudos-webapps/src/main/webapp/css/main.less
+++ b/kudos-webapps/src/main/webapp/css/main.less
@@ -209,12 +209,10 @@
 .kudosOverviewCardsParent, .kudosOverviewCard {
   .kudosReceivedOverviewPeriod, .kudosSentOverviewPeriod {
     max-width: 230px;
+    min-height:27px;
 
     .kudosOverviewLabel, .kudosOverviewCount {
       overflow-wrap: normal;
-      width: auto;
-      max-width: fit-content;
-      min-width: 44px;
       min-height: 47px;
     }
   }

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
@@ -6,64 +6,55 @@
       v-if="!isOverviewDisplay"
       id="kudosOverviewHeader"
       color="white"
-      height="48"
+      height="64"
       flat
-      class="border-box-sizing py-3">
-      <div class="text-header-title text-sub-title text-no-wrap">
-        {{ $t('exoplatform.kudos.button.rewardedKudos') }}
+      class="border-box-sizing">
+      <div class="d-flex flex py-3">
+        <div class="text-header-title text-sub-title text-no-wrap d-flex align-center">
+          {{ $t('exoplatform.kudos.button.rewardedKudos') }}
+        </div>
+        <v-spacer />
+        <select
+          v-model="periodType"
+          class="kudosOverviewPeriodSelect fill-height col-auto my-auto py-0 subtitle-1 ignore-vuetify-classes">
+          <option
+            v-for="period in periods"
+            :key="period.value"
+            :value="period.value">
+            {{ period.text }}
+          </option>
+        </select>
       </div>
-      <v-spacer />
-      <select
-        v-if="!isOverviewDisplay"
-        v-model="periodType"
-        class="kudosOverviewPeriodSelect fill-height col-auto me-2 my-auto px-3 py-0 subtitle-1 ignore-vuetify-classes">
-        <option
-          v-for="period in periods"
-          :key="period.value"
-          :value="period.value">
-          {{ period.text }}
-        </option>
-      </select>
     </v-toolbar>
     <v-row
       id="kudosOverviewCardsParent"
-      class="white border-box-sizing px-4 py-0 ma-0 align-center" 
-      :style="isOverviewDisplay && 'min-height:27px;' || ''">
+      class="white border-box-sizing px-4 py-0 ma-0 align-center">
       <v-col class="kudosOverviewCard">
         <kudos-overview-card
-          :is-overview-display="isOverviewDisplay"
           :clickable="owner && receivedKudosCount > 0"
           class="kudosReceivedOverviewPeriod mx-n4"
           @open-drawer="openDrawer('received')">
           <template slot="count">
             {{ receivedKudosCount || '0' }}
           </template>
-          <template v-if="isOverviewDisplay" slot="label">
+          <template slot="label">
             {{ $t('exoplatform.kudos.label.received') }}
           </template> 
-          <template v-else slot="label">
-            {{ $t('exoplatform.kudos.button.receivedKudos') }}
-          </template>
         </kudos-overview-card>
       </v-col>
       <v-divider
-        class="my-9 mx-8 mx-md-4"
-        :class="isOverviewDisplay && 'me-md-1 ms-md-5' || ''"
+        class="my-9 mx-8 me-md-1 ms-md-5"
         vertical />
       <v-col class="kudosOverviewCard">
         <kudos-overview-card
-          :is-overview-display="isOverviewDisplay"
           :clickable="owner && sentKudosCount > 0"
           class="kudosSentOverviewPeriod mx-n4"
           @open-drawer="openDrawer('sent')">
           <template slot="count">
             {{ sentKudosCount || '0' }}
           </template>
-          <template v-if="isOverviewDisplay" slot="label">
+          <template slot="label">
             {{ $t('exoplatform.kudos.label.sent') }}
-          </template>
-          <template v-else slot="label">
-            {{ $t('exoplatform.kudos.button.sentKudos') }}
           </template>
         </kudos-overview-card>
       </v-col>

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewCard.vue
@@ -1,22 +1,23 @@
 <template>
-  <v-row
+  <div
     :class="clickable && 'clickable' || ''"
-    class="border-box-sizing text-center justify-center"
+    class="border-box-sizing text-center justify-center align-center d-flex flex-wrap"
     @click="clickable && $emit('open-drawer')">
-    <v-col class="my-auto px-0 col-md-3 kudosOverviewIcon pa-0">
-      <v-icon class="tertiary-color uiIconAward" :size="isOverviewDisplay ? '40' : '56'" />
-    </v-col>
-    <v-col class="my-auto col-md-2 kudosOverviewCount text-color mx-0 display-1 font-weight-bold pa-0">
+    <div class="px-0 kudosOverviewIcon pa-0">
+      <v-icon class="tertiary-color uiIconAward" size="40" />
+    </div>
+    <div class="kudosOverviewCount text-color mx-2 display-1 font-weight-bold pa-0 d-flex align-center">
       <slot name="count"></slot>
-    </v-col>
-    <v-col class="my-auto col-12 col-md-1 text-md-left px-0 mx-0 kudosOverviewLabel text-color">
+    </div>
+    <div class="px-0 mx-0">
       <v-card
-        flat
-        :min-width="isOverviewDisplay ? '55' : '90'">
+        :min-width="55"
+        class="d-flex align-center flex-no-wrap"
+        flat>
         <slot name="label"></slot>
       </v-card>
-    </v-col>
-  </v-row>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -25,10 +26,6 @@ export default {
     clickable: {
       type: Boolean,
       default: null,
-    },
-    isOverviewDisplay: {
-      type: Boolean,
-      default: () => false,
     },
   },
 };


### PR DESCRIPTION
This change will adapt Kudos widget display to use the same display as done on Overview Page for Profile Page. At the same time, this will move the kudos block container to be displayed on right side of the profile page content.