### PR TITLE
fix: fix user full name and popover after updating user contact in kudos activity - EXO-59990

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/ProfileUpdateListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/ProfileUpdateListener.java
@@ -1,0 +1,59 @@
+package org.exoplatform.kudos.listener;
+
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
+import org.exoplatform.social.core.profile.ProfileListenerPlugin;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+
+import java.util.List;
+
+public class ProfileUpdateListener extends ProfileListenerPlugin {
+
+  private ActivityStorage activityStorage;
+
+  private KudosService    kudosService;
+
+  public ProfileUpdateListener(KudosService kudosService, ActivityStorage activityStorage) {
+    this.kudosService = kudosService;
+    this.activityStorage = activityStorage;
+  }
+
+  @Override
+  public void avatarUpdated(ProfileLifeCycleEvent event) {
+    String userId = event.getProfile().getIdentity().getId();
+    this.clearUserActivitiesCache(userId);
+  }
+
+  @Override
+  public void bannerUpdated(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void contactSectionUpdated(ProfileLifeCycleEvent event) {
+    String userId = event.getProfile().getIdentity().getId();
+    this.clearUserActivitiesCache(userId);
+  }
+
+  @Override
+  public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void createProfile(ProfileLifeCycleEvent event) {
+
+  }
+
+  private void clearUserActivitiesCache(String userId) {
+    if (activityStorage instanceof CachedActivityStorage) {
+      long count = kudosService.countKudosByPeriodAndReceiver(Long.parseLong(userId),0 , System.currentTimeMillis());
+      List<Kudos> kudosList = kudosService.getKudosByPeriodAndReceiver(Long.parseLong(userId),0 , System.currentTimeMillis(),(int) count);
+      if (kudosList == null || kudosList.isEmpty())
+        return;
+      kudosList.stream().forEach(kudos -> ((CachedActivityStorage) activityStorage).clearActivityCached(String.valueOf(kudos.getActivityId())));
+    }
+  }
+}

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/ProfileUpdateListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/ProfileUpdateListener.java
@@ -28,7 +28,7 @@ public class ProfileUpdateListener extends ProfileListenerPlugin {
 
   @Override
   public void bannerUpdated(ProfileLifeCycleEvent event) {
-
+    // NOSONAR
   }
 
   @Override
@@ -39,21 +39,24 @@ public class ProfileUpdateListener extends ProfileListenerPlugin {
 
   @Override
   public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
-
+    // NOSONAR
   }
 
   @Override
   public void createProfile(ProfileLifeCycleEvent event) {
-
+    // NOSONAR
   }
 
   private void clearUserActivitiesCache(String userId) {
-    if (activityStorage instanceof CachedActivityStorage) {
-      long count = kudosService.countKudosByPeriodAndReceiver(Long.parseLong(userId),0 , System.currentTimeMillis());
-      List<Kudos> kudosList = kudosService.getKudosByPeriodAndReceiver(Long.parseLong(userId),0 , System.currentTimeMillis(),(int) count);
-      if (kudosList == null || kudosList.isEmpty())
-        return;
-      kudosList.stream().forEach(kudos -> ((CachedActivityStorage) activityStorage).clearActivityCached(String.valueOf(kudos.getActivityId())));
-    }
+    long count = kudosService.countKudosByPeriodAndReceiver(Long.parseLong(userId), 0, System.currentTimeMillis());
+    List<Kudos> kudosList = kudosService.getKudosByPeriodAndReceiver(Long.parseLong(userId),
+                                                                     0,
+                                                                     System.currentTimeMillis(),
+                                                                     (int) count);
+    if (kudosList == null || kudosList.isEmpty())
+      return;
+    kudosList.stream()
+             .forEach(kudos -> ((CachedActivityStorage) activityStorage).clearActivityCached(String.valueOf(kudos.getActivityId())));
   }
+
 }

--- a/kudos-services/src/main/resources/conf/portal/configuration.xml
+++ b/kudos-services/src/main/resources/conf/portal/configuration.xml
@@ -74,4 +74,12 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.IdentityManager</target-component>
+    <component-plugin>
+      <name>ProfileUpdateListener</name>
+      <set-method>addProfileListener</set-method>
+      <type>org.exoplatform.kudos.listener.ProfileUpdateListener</type>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/ProfileUpdateListenerTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/ProfileUpdateListenerTest.java
@@ -1,0 +1,81 @@
+package org.exoplatform.kudos.test.listener;
+
+import org.exoplatform.commons.testing.BaseExoTestCase;
+import org.exoplatform.kudos.listener.ProfileUpdateListener;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProfileUpdateListenerTest extends BaseExoTestCase {
+  private IdentityManager identityManager;
+
+  private KudosService    kudosService;
+
+  private ActivityStorage activityStorage;
+
+  public void setUp() throws Exception {
+    super.setUp();
+    identityManager = getContainer().getComponentInstanceOfType(IdentityManager.class);
+  }
+
+  public void testUpdateProfileAndDetectChanges() {
+    Identity rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root1");
+    Profile profile = rootIdentity.getProfile();
+    List<Integer> changes = new ArrayList<>();
+    identityManager.registerProfileListener(new ProfileUpdateListener(kudosService, activityStorage) {
+      @Override
+      public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
+      }
+
+      @Override
+      public void createProfile(ProfileLifeCycleEvent event) {
+        // noop
+      }
+
+      @Override
+      public void technicalUpdated(ProfileLifeCycleEvent event) {
+        // noop
+      }
+
+      @Override
+      public void contactSectionUpdated(ProfileLifeCycleEvent event) {
+        changes.add(1);
+      }
+
+      @Override
+      public void bannerUpdated(ProfileLifeCycleEvent event) {
+      }
+
+      @Override
+      public void avatarUpdated(ProfileLifeCycleEvent event) {
+        changes.add(2);
+      }
+
+      @Override
+      public void aboutMeUpdated(ProfileLifeCycleEvent event) {
+      }
+    });
+    profile.setProperty(Profile.FIRST_NAME, "Changed Firstname");
+    identityManager.updateProfile(profile);
+    assertEquals(1, changes.size());
+    assertTrue(changes.contains(1));
+
+    profile.setProperty(Profile.ABOUT_ME, "Changed ABOUT_ME");
+    profile.removeProperty(Profile.FIRST_NAME);
+    identityManager.updateProfile(profile);
+    assertEquals(1, changes.size());
+    assertTrue(changes.contains(1));
+    profile.setProperty(Profile.AVATAR, "new/avatar");
+    identityManager.updateProfile(profile);
+    assertEquals(2, changes.size());
+    assertTrue(changes.contains(2));
+  }
+
+}

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/IdentityManagerMock.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/IdentityManagerMock.java
@@ -21,6 +21,9 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.storage.api.IdentityStorage;
 
 public class IdentityManagerMock implements IdentityManager {
+
+  protected ProfileLifeCycle                 profileLifeCycle  = new ProfileLifeCycle();
+
   List<Identity> identities = new ArrayList<>();
 
   public IdentityManagerMock() {
@@ -30,6 +33,7 @@ public class IdentityManagerMock implements IdentityManager {
       identity.setEnable(true);
       identity.setProviderId(OrganizationIdentityProvider.NAME);
       identity.setRemoteId("root" + i);
+      identity.setId(String.valueOf(i));
       Profile profile = new Profile(identity);
       identity.setProfile(profile);
       identities.add(identity);
@@ -136,7 +140,16 @@ public class IdentityManagerMock implements IdentityManager {
 
   @Override
   public void updateProfile(Profile specificProfile) {
-    // empty
+    List<Profile.UpdateType> list = new ArrayList<>();
+    if (specificProfile.getProperty(Profile.FIRST_NAME) != null || specificProfile.getProperty(Profile.POSITION) != null ) {
+      list.add(Profile.UpdateType.CONTACT);
+    }
+    if (specificProfile.getProperty(Profile.AVATAR) != null){
+      list.add(Profile.UpdateType.AVATAR);
+    }
+    for (Profile.UpdateType type : list) {
+      type.updateActivity(profileLifeCycle, specificProfile);
+    }
   }
 
   @Override
@@ -171,7 +184,7 @@ public class IdentityManagerMock implements IdentityManager {
 
   @Override
   public void registerProfileListener(ProfileListenerPlugin profileListenerPlugin) {
-    throw new UnsupportedOperationException();
+    profileLifeCycle.addListener(profileListenerPlugin);
   }
 
   @Override

--- a/kudos-services/src/test/resources/conf/configuration.xml
+++ b/kudos-services/src/test/resources/conf/configuration.xml
@@ -16,6 +16,22 @@
     </init-params>
   </component>
 
+
+  <component>
+    <key>org.exoplatform.social.common.lifecycle.LifeCycleCompletionService</key>
+    <type>org.exoplatform.social.common.lifecycle.LifeCycleCompletionService</type>
+    <init-params>
+      <value-param>
+        <name>thread-number</name>
+        <value>10</value>
+      </value-param>
+      <value-param>
+        <name>async-execution</name>
+        <value>false</value>
+      </value-param>
+    </init-params>
+  </component>
+
   <!-- Bind datasource -->
   <external-component-plugins>
     <target-component>org.exoplatform.services.naming.InitialContextInitializer</target-component>


### PR DESCRIPTION
prior to this change, when the user had updated his contact info (his name or job title), the user popover in the kudos activity still displayed old user info, since the activity is cached
prior to this change, after updated user contact, kudos activities cache is cleared