### PR TITLE
fix: Fix Cancel Sending Kudos Achievement status - MEED-2027 - Meeds-io/meeds#921

### DIFF
--- a/kudos-services/pom.xml
+++ b/kudos-services/pom.xml
@@ -12,7 +12,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Kudos addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.62</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.64</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/kudos-services/src/main/java/org/exoplatform/kudos/exception/KudosAlreadyLinkedException.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/exception/KudosAlreadyLinkedException.java
@@ -16,6 +16,8 @@
 package org.exoplatform.kudos.exception;
 
 public class KudosAlreadyLinkedException extends Exception {
+  private static final long serialVersionUID = -91701909117712293L;
+
   public KudosAlreadyLinkedException() {
   }
 

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/GamificationIntegrationListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/GamificationIntegrationListener.java
@@ -1,24 +1,40 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exoplatform.kudos.listener;
 
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_CANCEL_EVENT;
 import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_GENERIC_EVENT;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_OBJECT_TYPE;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_RECEIVE_KUDOS_EVENT_NAME;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_SEND_KUDOS_EVENT_NAME;
 import static org.exoplatform.kudos.service.utils.Utils.KUDOS_ACTIVITY_EVENT;
 import static org.exoplatform.kudos.service.utils.Utils.KUDOS_CANCEL_ACTIVITY_EVENT;
-import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_CANCEL_EVENT;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.kudos.model.Kudos;
 import org.exoplatform.kudos.service.KudosService;
-import org.exoplatform.services.listener.*;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.activity.model.ExoSocialActivity;
-import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
 
 /**
  * A listener to add comment or activity
@@ -26,83 +42,58 @@ import org.exoplatform.social.core.manager.ActivityManager;
 @Asynchronous
 public class GamificationIntegrationListener extends Listener<KudosService, Kudos> {
 
-  private static final Log LOG = ExoLogger.getLogger(GamificationIntegrationListener.class);
+  private ListenerService     listenerService;
 
-  private ListenerService  listenerService;
-
-  private ActivityManager  activityManager;
-
-  private PortalContainer  container;
-
-  public GamificationIntegrationListener(PortalContainer container, ListenerService listenerService) {
-    this.container = container;
+  public GamificationIntegrationListener(ListenerService listenerService) {
     this.listenerService = listenerService;
   }
 
   @Override
-  public void onEvent(Event<KudosService, Kudos> event) {
-    ExoContainerContext.setCurrentContainer(container);
-    RequestLifeCycle.begin(container);
-    try {
-      Kudos kudos = event.getData();
-      try {
-        Map<String, String> gam = new HashMap<>();
-        gam.put("ruleTitle", "sendKudos");
-        ExoSocialActivity activity = getActivityManager().getActivity(String.valueOf(kudos.getActivityId()));
-        gam.put("objectId", activity.getId());
-        gam.put("objectType", "activity");
-        gam.put("senderId", kudos.getSenderId()); // matches the gamification's earner id
-        gam.put("receiverId", kudos.getReceiverId());
-        switch (event.getEventName()) {
-        case KUDOS_ACTIVITY_EVENT: {
-          listenerService.broadcast(GAMIFICATION_GENERIC_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
-          break;
-        }
-        case KUDOS_CANCEL_ACTIVITY_EVENT: {
-          listenerService.broadcast(GAMIFICATION_CANCEL_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
-          getActivityManager().deleteActivity(String.valueOf(kudos.getActivityId()));
-          break;
-        }
-        default:
-          throw new IllegalArgumentException("Unexpected listener event name: " + event.getEventName());
-        }
-      } catch (Exception e) {
-        LOG.error("Cannot broadcast gamification event");
-      }
+  @ExoTransactional
+  public void onEvent(Event<KudosService, Kudos> event) throws Exception {
+    Kudos kudos = event.getData();
+    String eventName = event.getEventName();
 
-      try {
-        Map<String, String> gam = new HashMap<>();
-        gam.put("ruleTitle", "receiveKudos");
-        ExoSocialActivity activity = getActivityManager().getActivity(String.valueOf(kudos.getActivityId()));
-        gam.put("objectId", activity.getId());
-        gam.put("objectType", "activity");
-        gam.put("senderId", kudos.getReceiverId()); // matches the gamification's earner id
-        gam.put("receiverId", kudos.getSenderId());
-        switch (event.getEventName()) {
-        case KUDOS_ACTIVITY_EVENT: {
-          listenerService.broadcast(GAMIFICATION_GENERIC_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
-          break;
-        }
-        case KUDOS_CANCEL_ACTIVITY_EVENT: {
-          listenerService.broadcast(GAMIFICATION_CANCEL_EVENT, gam, String.valueOf(kudos.getTechnicalId()));
-          break;
-        }
-        default:
-          throw new IllegalArgumentException("Unexpected listener event name: " + event.getEventName());
-        }
-      } catch (Exception e) {
-        LOG.error("Cannot broadcast gamification event");
-      }
-
-    } finally {
-      RequestLifeCycle.end();
-    }
+    saveSendKudosAchievement(kudos, eventName);
+    saveRecieveKudosAchievement(kudos, eventName);
   }
 
-  public ActivityManager getActivityManager() {
-    if (activityManager == null) {
-      activityManager = CommonsUtils.getService(ActivityManager.class);
-    }
-    return activityManager;
+  private void saveSendKudosAchievement(Kudos kudos, String eventName) throws Exception {
+    Map<String, String> gam = buildGamificationEventDetails(GAMIFICATION_SEND_KUDOS_EVENT_NAME,
+                                                            kudos.getSenderId(),
+                                                            kudos.getReceiverId(),
+                                                            String.valueOf(kudos.getActivityId()));
+    listenerService.broadcast(getGamificationEventName(eventName), gam, String.valueOf(kudos.getTechnicalId()));
   }
+
+  private void saveRecieveKudosAchievement(Kudos kudos, String eventName) throws Exception {
+    Map<String, String> gam = buildGamificationEventDetails(GAMIFICATION_RECEIVE_KUDOS_EVENT_NAME,
+                                                            kudos.getReceiverId(),
+                                                            kudos.getSenderId(),
+                                                            String.valueOf(kudos.getActivityId()));
+    listenerService.broadcast(getGamificationEventName(eventName), gam, String.valueOf(kudos.getTechnicalId()));
+  }
+
+  private String getGamificationEventName(String eventName) {
+    return switch (eventName) {
+    case KUDOS_ACTIVITY_EVENT -> GAMIFICATION_GENERIC_EVENT;
+    case KUDOS_CANCEL_ACTIVITY_EVENT -> GAMIFICATION_CANCEL_EVENT;
+    default -> throw new IllegalArgumentException("Unexpected listener event name: " + eventName);
+    };
+  }
+
+  private Map<String, String> buildGamificationEventDetails(String gamificationEventName,
+                                                            String earnerId,
+                                                            String receiverId,
+                                                            String objectId) {
+    Map<String, String> gam = new HashMap<>();
+    gam.put("objectType", GAMIFICATION_OBJECT_TYPE);
+    gam.put("objectId", objectId);
+    gam.put("ruleTitle", gamificationEventName);
+    gam.put("senderId", earnerId); // matches the gamification's
+                                   // earner id
+    gam.put("receiverId", receiverId);
+    return gam;
+  }
+
 }

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosActivityListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosActivityListener.java
@@ -69,11 +69,8 @@ public class KudosActivityListener extends ActivityListenerPlugin {
 
   @Override
   public void deleteComment(ActivityLifeCycleEvent activityLifeCycleEvent) {
-    ExoSocialActivity activity = activityLifeCycleEvent.getSource();
-    List<Kudos> linkedKudosList = kudosService.getKudosListOfActivity(activity.getId());
-    if (!linkedKudosList.isEmpty()) {
-      deleteLinkedKudos(linkedKudosList);
-    }
+    // Same as activity processing
+    deleteActivity(activityLifeCycleEvent);
   }
 
   @Override

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosCanceledListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosCanceledListener.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.kudos.listener;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.manager.ActivityManager;
+
+@Asynchronous
+public class KudosCanceledListener extends Listener<KudosService, Kudos> {
+
+  private PortalContainer container;
+
+  public KudosCanceledListener(PortalContainer container) {
+    this.container = container;
+  }
+
+  @Override
+  @ExoTransactional
+  public void onEvent(Event<KudosService, Kudos> event) throws Exception {
+    Kudos kudos = event.getData();
+    if (kudos != null && kudos.getActivityId() > 0) {
+      container.getComponentInstanceOfType(ActivityManager.class).deleteActivity(String.valueOf(kudos.getActivityId()));
+    }
+  }
+
+}

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosSentActivityGeneratorListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosSentActivityGeneratorListener.java
@@ -23,20 +23,20 @@ import org.exoplatform.social.notification.Utils;
 /**
  * A listener to add comment or activity
  */
-public class NewKudosSentActivityGeneratorListener extends Listener<KudosService, Kudos> {
-  private static final Log LOG = ExoLogger.getLogger(NewKudosSentActivityGeneratorListener.class);
+public class KudosSentActivityGeneratorListener extends Listener<KudosService, Kudos> {
+  private static final Log LOG = ExoLogger.getLogger(KudosSentActivityGeneratorListener.class);
 
   private ActivityStorage  activityStorage;
 
   private ActivityManager  activityManager;
 
-  public NewKudosSentActivityGeneratorListener(ActivityManager activityManager, ActivityStorage activityStorage) {
+  public KudosSentActivityGeneratorListener(ActivityManager activityManager, ActivityStorage activityStorage) {
     this.activityManager = activityManager;
     this.activityStorage = activityStorage;
   }
 
   @Override
-  public void onEvent(Event<KudosService, Kudos> event) throws Exception {
+  public void onEvent(Event<KudosService, Kudos> event) throws Exception { // NOSONAR
     Kudos kudos = event.getData();
     KudosService kudosService = event.getSource();
 
@@ -68,10 +68,8 @@ public class NewKudosSentActivityGeneratorListener extends Listener<KudosService
         kudos.setActivityId(commentId);
         kudosService.updateKudosGeneratedActivityId(kudos.getTechnicalId(), kudos.getActivityId());
 
-        if (activityStorage instanceof CachedActivityStorage) {
-          ((CachedActivityStorage) activityStorage).clearActivityCached(activity.getId());
-          ((CachedActivityStorage) activityStorage).clearActivityCached(activityComment.getId());
-        }
+        clearActivityCached(activity.getId());
+        clearActivityCached(activityComment.getId());
       } catch (Exception e) {
         LOG.warn("Error adding comment on activity with id '" + activityId + "' for Kudos with id " + kudos.getTechnicalId(), e);
       }
@@ -94,9 +92,7 @@ public class NewKudosSentActivityGeneratorListener extends Listener<KudosService
         activityManager.saveActivityNoReturn(owner, activity);
         kudosService.updateKudosGeneratedActivityId(kudos.getTechnicalId(),
                                                     org.exoplatform.kudos.service.utils.Utils.getActivityId(activity.getId()));
-        if (activityStorage instanceof CachedActivityStorage) {
-          ((CachedActivityStorage) activityStorage).clearActivityCached(activity.getId());
-        }
+        clearActivityCached(activity.getId());
       }
     }
   }
@@ -110,6 +106,12 @@ public class NewKudosSentActivityGeneratorListener extends Listener<KudosService
     activity.setUserId(kudos.getSenderIdentityId());
     org.exoplatform.kudos.service.utils.Utils.computeKudosActivityProperties(activity, kudos);
     return activity;
+  }
+
+  private void clearActivityCached(String id) {
+    if (activityStorage instanceof CachedActivityStorage cachedActivityStorage) {
+      cachedActivityStorage.clearActivityCached(id);
+    }
   }
 
 }

--- a/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosSentNotificationListener.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/listener/KudosSentNotificationListener.java
@@ -16,8 +16,8 @@ import org.exoplatform.services.log.Log;
 /**
  * A listener to send notification after sending a new Kudos
  */
-public class NewKudosSentNotificationListener extends Listener<KudosService, Kudos> {
-  private static final Log LOG = ExoLogger.getLogger(NewKudosSentNotificationListener.class);
+public class KudosSentNotificationListener extends Listener<KudosService, Kudos> {
+  private static final Log LOG = ExoLogger.getLogger(KudosSentNotificationListener.class);
 
   @Override
   public void onEvent(Event<KudosService, Kudos> event) throws Exception {

--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/builder/KudosTemplateBuilder.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/builder/KudosTemplateBuilder.java
@@ -6,7 +6,6 @@ import java.io.Writer;
 import java.util.Calendar;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
@@ -20,7 +19,6 @@ import org.exoplatform.commons.notification.template.TemplateUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
-import org.exoplatform.social.common.xmlprocessor.XMLProcessorImpl;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -46,7 +44,7 @@ public class KudosTemplateBuilder extends AbstractTemplateBuilder {
   }
 
   @Override
-  protected MessageInfo makeMessage(NotificationContext ctx) {
+  protected MessageInfo makeMessage(NotificationContext ctx) { // NOSONAR
     NotificationInfo notification = ctx.getNotificationInfo();
     String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
     ExoSocialActivity activity = null;

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/KudosService.java
@@ -196,10 +196,10 @@ public class KudosService implements ExoKudosStatisticService, Startable {
     Object receiverObject = checkStatusAndGetReceiver(kudos.getReceiverType(), kudos.getReceiverId());
 
     if (kudos.getReceiverIdentityId() == null) {
-      if (receiverObject instanceof Identity) {
-        kudos.setReceiverIdentityId(((Identity) receiverObject).getId());
-      } else if (receiverObject instanceof Space) {
-        kudos.setReceiverIdentityId(((Space) receiverObject).getId());
+      if (receiverObject instanceof Identity identity) {
+        kudos.setReceiverIdentityId(identity.getId());
+      } else if (receiverObject instanceof Space space) {
+        kudos.setReceiverIdentityId(space.getId());
       }
     }
 
@@ -217,9 +217,8 @@ public class KudosService implements ExoKudosStatisticService, Startable {
    *
    * @param kudosId Kudos technical identifier to delete
    * @param username User name deleting kudos
-   * @throws IllegalAccessException when user is not authorized to delete the
-   *           kudos
-   * @throws ObjectNotFoundException when the kudos identified by its technical
+   * @throws Exception when user is not authorized to delete the
+   *           kudos or when the kudos identified by its technical
    *           identifier is not found
    */
   public void deleteKudosById(long kudosId, String username) throws Exception {
@@ -546,7 +545,7 @@ public class KudosService implements ExoKudosStatisticService, Startable {
   @Override
   public Map<String, Object> getStatisticParameters(String operation, Object result, Object... methodArgs) {
     if (result == null) {
-      return null;
+      return Collections.emptyMap();
     }
     Map<String, Object> parameters = new HashMap<>();
 

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
@@ -2,7 +2,6 @@ package org.exoplatform.kudos.service.utils;
 
 import java.time.*;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -32,50 +31,56 @@ import org.exoplatform.social.core.utils.MentionUtils;
 import static org.exoplatform.social.core.manager.ActivityManagerImpl.REMOVABLE;
 
 public class Utils {
-  private static final Log                   LOG                             = ExoLogger.getLogger(Utils.class);
+  private static final Log                   LOG                                   = ExoLogger.getLogger(Utils.class);
 
-  public static final String                 KUDOS_ICON                      =
+  public static final String                 KUDOS_ICON                            =
                                                         "<i class='uiIcon fa fa-award uiIconKudos uiIconBlue'></i>";
 
-  public static final String                 SCOPE_NAME                      = "ADDONS_KUDOS";
+  public static final String                 SCOPE_NAME                            = "ADDONS_KUDOS";
 
-  public static final String                 SETTINGS_KEY_NAME               = "ADDONS_KUDOS_SETTINGS";
+  public static final String                 SETTINGS_KEY_NAME                     = "ADDONS_KUDOS_SETTINGS";
 
-  public static final Context                KUDOS_CONTEXT                   = Context.GLOBAL;
+  public static final Context                KUDOS_CONTEXT                         = Context.GLOBAL;
 
-  public static final Scope                  KUDOS_SCOPE                     = Scope.APPLICATION.id(SCOPE_NAME);
+  public static final Scope                  KUDOS_SCOPE                           = Scope.APPLICATION.id(SCOPE_NAME);
 
-  public static final String                 SPACE_ACCOUNT_TYPE              = SpaceIdentityProvider.NAME;
+  public static final String                 SPACE_ACCOUNT_TYPE                    = SpaceIdentityProvider.NAME;
 
-  public static final String                 USER_ACCOUNT_TYPE               = "user";
+  public static final String                 USER_ACCOUNT_TYPE                     = "user";
 
-  public static final String                 DEFAULT_ACCESS_PERMISSION       = "defaultAccessPermission";
+  public static final String                 DEFAULT_ACCESS_PERMISSION             = "defaultAccessPermission";
 
-  public static final String                 DEFAULT_KUDOS_PER_PERIOD        = "defaultKudosPerPeriod";
+  public static final String                 DEFAULT_KUDOS_PER_PERIOD              = "defaultKudosPerPeriod";
 
-  public static final String                 KUDOS_RECEIVER_NOTIFICATION_ID  = "KudosActivityReceiverNotificationPlugin";
+  public static final String                 KUDOS_RECEIVER_NOTIFICATION_ID        = "KudosActivityReceiverNotificationPlugin";
 
-  public static final String                 KUDOS_SENT_EVENT                = "exo.kudos.sent";
+  public static final String                 KUDOS_SENT_EVENT                      = "exo.kudos.sent";
 
-  public static final String                 KUDOS_ACTIVITY_EVENT            = "exo.kudos.activity";
+  public static final String                 KUDOS_ACTIVITY_EVENT                  = "exo.kudos.activity";
 
-  public static final String                 GAMIFICATION_GENERIC_EVENT      = "exo.gamification.generic.action";
+  public static final String                 GAMIFICATION_GENERIC_EVENT            = "exo.gamification.generic.action";
 
-  public static final String                 KUDOS_CANCEL_ACTIVITY_EVENT     = "kudos.cancel.activity";
+  public static final String                 KUDOS_CANCEL_ACTIVITY_EVENT           = "kudos.cancel.activity";
 
-  public static final String                 GAMIFICATION_CANCEL_EVENT       = "gamification.cancel.event.action";
+  public static final String                 GAMIFICATION_CANCEL_EVENT             = "gamification.cancel.event.action";
 
-  public static final String                 KUDOS_ACTIVITY_COMMENT_TYPE     = "exokudos:activity";
+  public static final String                 GAMIFICATION_RECEIVE_KUDOS_EVENT_NAME = "receiveKudos";
 
-  public static final String                 KUDOS_ACTIVITY_COMMENT_TITLE_ID = "activity_kudos_content";
+  public static final String                 GAMIFICATION_SEND_KUDOS_EVENT_NAME    = "sendKudos";
 
-  public static final String                 KUDOS_MESSAGE_PARAM             = "kudosMessage";
+  public static final String                 GAMIFICATION_OBJECT_TYPE              = "activity";
 
-  public static final ArgumentLiteral<Kudos> KUDOS_DETAILS_PARAMETER         = new ArgumentLiteral<>(Kudos.class, "kudos");
+  public static final String                 KUDOS_ACTIVITY_COMMENT_TYPE           = "exokudos:activity";
 
-  public static final String                 ACTIVITY_COMMENT_ID_PREFIX      = "comment";
+  public static final String                 KUDOS_ACTIVITY_COMMENT_TITLE_ID       = "activity_kudos_content";
 
-  public static final String                 CONTENT_TYPE                    = "contentType";
+  public static final String                 KUDOS_MESSAGE_PARAM                   = "kudosMessage";
+
+  public static final ArgumentLiteral<Kudos> KUDOS_DETAILS_PARAMETER               = new ArgumentLiteral<>(Kudos.class, "kudos");
+
+  public static final String                 ACTIVITY_COMMENT_ID_PREFIX            = "comment";
+
+  public static final String                 CONTENT_TYPE                          = "contentType";
 
   private Utils() {
   }
@@ -120,7 +125,7 @@ public class Utils {
         } else if (StringUtils.isBlank(senderId)) {
           return Arrays.asList(members);
         } else {
-          return Arrays.stream(members).filter(member -> !senderId.equals(member)).collect(Collectors.toList());
+          return Arrays.stream(members).filter(member -> !senderId.equals(member)).toList();
         }
       }
     } else {
@@ -161,7 +166,9 @@ public class Utils {
       kudos.setReceiverIdentityId(getIdentityIdByType(receiverIdentity));
       kudos.setReceiverType(USER_ACCOUNT_TYPE);
       kudos.setReceiverPosition(StringEscapeUtils.unescapeHtml(receiverIdentity.getProfile().getPosition()));
-      kudos.setExternalReceiver(receiverIdentity.getProfile() != null && receiverIdentity.getProfile().getProperty("external") != null && receiverIdentity.getProfile().getProperty("external").equals("true"));
+      kudos.setExternalReceiver(receiverIdentity.getProfile() != null
+          && receiverIdentity.getProfile().getProperty("external") != null
+          && receiverIdentity.getProfile().getProperty("external").equals("true"));
       kudos.setReceiverFullName(receiverIdentity.getProfile().getFullName());
       kudos.setReceiverURL(LinkProvider.getUserProfileUri(receiverIdentity.getRemoteId()));
       kudos.setReceiverAvatar(getAvatar(receiverIdentity, null));

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/GamificationIntegrationListenerTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/GamificationIntegrationListenerTest.java
@@ -1,0 +1,159 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.kudos.test.listener;
+
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_CANCEL_EVENT;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_GENERIC_EVENT;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_RECEIVE_KUDOS_EVENT_NAME;
+import static org.exoplatform.kudos.service.utils.Utils.GAMIFICATION_SEND_KUDOS_EVENT_NAME;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.codec.binary.StringUtils;
+import org.junit.Test;
+
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.model.KudosEntityType;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.kudos.test.BaseKudosTest;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+
+public class GamificationIntegrationListenerTest extends BaseKudosTest {
+
+  private static final String     SENDER_REMOTE_ID                       = "root4";
+
+  private static final AtomicLong GAMIFICATION_SEND_KUDOS_EVENT_COUNT    = new AtomicLong();
+
+  private static final AtomicLong GAMIFICATION_RECEIVE_KUDOS_EVENT_COUNT = new AtomicLong();
+
+  private static final AtomicLong GAMIFICATION_SAVE_KUDOS_EVENT_COUNT    = new AtomicLong();
+
+  private static final AtomicLong GAMIFICATION_CANCEL_KUDOS_EVENT_COUNT  = new AtomicLong();
+
+  private static final AtomicLong GAMIFICATION_LISTENER_COUNT            = new AtomicLong();
+
+  private static boolean          listenerInstalled;
+
+  private KudosService            kudosService;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    kudosService = getService(KudosService.class);
+    resetCounters();
+    if (!listenerInstalled) {
+      Listener<Map<String, String>, String> listener = newListener();
+      ListenerService listenerService = getService(ListenerService.class);
+      listenerService.addListener(GAMIFICATION_GENERIC_EVENT, listener);
+      listenerService.addListener(GAMIFICATION_CANCEL_EVENT, listener);
+      listenerInstalled = true;
+    }
+  }
+
+  @Test
+  public void testCreateKudos() throws Exception {
+    createKudos();
+    waitForListenerToBeCalled();
+
+    assertEquals(1, GAMIFICATION_SEND_KUDOS_EVENT_COUNT.get());
+    assertEquals(1, GAMIFICATION_RECEIVE_KUDOS_EVENT_COUNT.get());
+    assertEquals(2, GAMIFICATION_SAVE_KUDOS_EVENT_COUNT.get());
+    assertEquals(0, GAMIFICATION_CANCEL_KUDOS_EVENT_COUNT.get());
+  }
+
+  @Test
+  public void testCancelKudosById() throws Exception {
+    Kudos kudos = createKudos();
+    waitForListenerToBeCalled();
+
+    resetCounters();
+    kudosService.deleteKudosById(kudos.getTechnicalId(), SENDER_REMOTE_ID);
+    waitForListenerToBeCalled();
+
+    assertEquals(1, GAMIFICATION_SEND_KUDOS_EVENT_COUNT.get());
+    assertEquals(1, GAMIFICATION_RECEIVE_KUDOS_EVENT_COUNT.get());
+    assertEquals(0, GAMIFICATION_SAVE_KUDOS_EVENT_COUNT.get());
+    assertEquals(2, GAMIFICATION_CANCEL_KUDOS_EVENT_COUNT.get());
+  }
+
+  private Kudos createKudos() throws Exception {
+    Kudos kudos = newKudosDTO();
+    kudos.setEntityType(KudosEntityType.USER_PROFILE.name());
+    return kudosService.createKudos(kudos, SENDER_REMOTE_ID);
+  }
+
+  private Listener<Map<String, String>, String> newListener() {
+    return new GamificationTestListener();
+  }
+
+  private void resetCounters() {
+    GAMIFICATION_LISTENER_COUNT.set(0);
+    GAMIFICATION_SEND_KUDOS_EVENT_COUNT.set(0);
+    GAMIFICATION_RECEIVE_KUDOS_EVENT_COUNT.set(0);
+    GAMIFICATION_SAVE_KUDOS_EVENT_COUNT.set(0);
+    GAMIFICATION_CANCEL_KUDOS_EVENT_COUNT.set(0);
+  }
+
+  private void waitForListenerToBeCalled() {
+    int tentatives = 3;
+    while (tentatives-- > 0) {
+      if (GAMIFICATION_LISTENER_COUNT.get() == 2) {
+        break;
+      } else if (GAMIFICATION_LISTENER_COUNT.get() > 2) {
+        throw new IllegalStateException("Listener shouldn't be invoked more than twice, but was: "
+            + GAMIFICATION_LISTENER_COUNT.get());
+      }
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    assertTrue("Listener seems not being executed after 3 tentatives", tentatives >= 0);
+  }
+
+  @Asynchronous
+  public static class GamificationTestListener extends Listener<Map<String, String>, String> {
+    @Override
+    public void onEvent(Event<Map<String, String>, String> event) throws Exception {
+      try {
+        String eventName = event.getEventName();
+        if (StringUtils.equals(eventName, GAMIFICATION_GENERIC_EVENT)) {
+          GAMIFICATION_SAVE_KUDOS_EVENT_COUNT.incrementAndGet();
+        } else if (StringUtils.equals(eventName, GAMIFICATION_CANCEL_EVENT)) {
+          GAMIFICATION_CANCEL_KUDOS_EVENT_COUNT.incrementAndGet();
+        }
+        Map<String, String> gamificationMap = event.getSource();
+        assertNotNull(gamificationMap);
+        String ruleTitle = gamificationMap.get("ruleTitle");
+        if (StringUtils.equals(ruleTitle, GAMIFICATION_SEND_KUDOS_EVENT_NAME)) {
+          GAMIFICATION_SEND_KUDOS_EVENT_COUNT.incrementAndGet();
+        } else if (StringUtils.equals(ruleTitle, GAMIFICATION_RECEIVE_KUDOS_EVENT_NAME)) {
+          GAMIFICATION_RECEIVE_KUDOS_EVENT_COUNT.incrementAndGet();
+        }
+      } finally {
+        GAMIFICATION_LISTENER_COUNT.incrementAndGet();
+      }
+    }
+  }
+
+}

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/ProfileUpdateListenerTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/listener/ProfileUpdateListenerTest.java
@@ -1,6 +1,5 @@
 package org.exoplatform.kudos.test.listener;
 
-import org.exoplatform.commons.testing.BaseExoTestCase;
 import org.exoplatform.kudos.listener.ProfileUpdateListener;
 import org.exoplatform.kudos.model.Kudos;
 import org.exoplatform.kudos.service.KudosService;
@@ -9,7 +8,6 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.storage.api.ActivityStorage;
 import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
 import org.junit.Test;

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/rest/KudosRestTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/rest/KudosRestTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.exoplatform.kudos.entity.KudosEntity;
-import org.exoplatform.kudos.listener.NewKudosSentActivityGeneratorListener;
+import org.exoplatform.kudos.listener.KudosSentActivityGeneratorListener;
 import org.exoplatform.kudos.model.Kudos;
 import org.exoplatform.kudos.model.KudosEntityType;
 import org.exoplatform.kudos.model.KudosList;
@@ -195,7 +195,7 @@ public class KudosRestTest extends BaseKudosRestTest {
     assertNull(kudosByActivity);
 
     ActivityManager activityManager = getService(ActivityManager.class);
-    new NewKudosSentActivityGeneratorListener(activityManager, null).onEvent(new Event<KudosService, Kudos>(null,
+    new KudosSentActivityGeneratorListener(activityManager, null).onEvent(new Event<KudosService, Kudos>(null,
                                                                                                             kudosService,
                                                                                                             kudos));
     List<Kudos> kudosList = kudosService.getKudosByEntity(kudos.getEntityType(), kudos.getEntityId(), 1);

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/service/KudosServiceTest.java
@@ -13,8 +13,6 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.junit.Test;
 
 import org.exoplatform.kudos.entity.KudosEntity;
-import org.exoplatform.kudos.listener.GamificationIntegrationListener;
-import org.exoplatform.kudos.listener.NewKudosSentActivityGeneratorListener;
 import org.exoplatform.kudos.model.AccountSettings;
 import org.exoplatform.kudos.model.GlobalSettings;
 import org.exoplatform.kudos.model.Kudos;
@@ -528,13 +526,6 @@ public class KudosServiceTest extends BaseKudosTest {
     KudosService kudosService = getService(KudosService.class);
     KudosStorage kudosStorage = getService(KudosStorage.class);
     ListenerService listenerService = getService(ListenerService.class);
-    ActivityManager activityManager = getService(ActivityManager.class);
-
-    listenerService.addListener(Utils.KUDOS_SENT_EVENT,
-                                new NewKudosSentActivityGeneratorListener(activityManager, null));
-
-    listenerService.addListener(Utils.KUDOS_ACTIVITY_EVENT,
-                                new GamificationIntegrationListener(container, listenerService));
 
     final AtomicBoolean listenerInvoked = new AtomicBoolean(false);
     listenerService.addListener(Utils.GAMIFICATION_GENERIC_EVENT, new Listener<KudosService, Kudos>() {
@@ -671,6 +662,23 @@ public class KudosServiceTest extends BaseKudosTest {
     kudos = kudosService.createKudos(kudos, SENDER_REMOTE_ID);
     long kudosId = kudos.getTechnicalId();
 
+    assertThrows(IllegalArgumentException.class, () -> kudosService.deleteKudosById(0, "root4"));
+    assertThrows(ObjectNotFoundException.class, () -> kudosService.deleteKudosById(100, "root4"));
+    assertThrows(IllegalAccessException.class, () -> kudosService.deleteKudosById(kudosId, "root3"));
+    kudosService.deleteKudosById(kudosId, "root4");
+    Kudos kudos1 = kudosStorage.getKudoById(kudos.getTechnicalId());
+    assertNull(kudos1);
+  }
+
+  @Test
+  public void testCancelKudosById() throws Exception {
+    KudosService kudosService = getService(KudosService.class);
+    KudosStorage kudosStorage = getService(KudosStorage.class);
+    Kudos kudos = newKudosDTO();
+    kudos.setEntityType(KudosEntityType.USER_PROFILE.name());
+    kudos = kudosService.createKudos(kudos, SENDER_REMOTE_ID);
+    long kudosId = kudos.getTechnicalId();
+    
     assertThrows(IllegalArgumentException.class, () -> kudosService.deleteKudosById(0, "root4"));
     assertThrows(ObjectNotFoundException.class, () -> kudosService.deleteKudosById(100, "root4"));
     assertThrows(IllegalAccessException.class, () -> kudosService.deleteKudosById(kudosId, "root3"));

--- a/kudos-services/src/test/resources/conf/kudos-test-configuration.xml
+++ b/kudos-services/src/test/resources/conf/kudos-test-configuration.xml
@@ -23,5 +23,34 @@
     <type>org.exoplatform.kudos.test.mock.ActivityManagerMock</type>
   </component>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>exo.kudos.activity</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.KudosSentNotificationListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.kudos.sent</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.KudosSentActivityGeneratorListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.kudos.activity</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.GamificationIntegrationListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>kudos.cancel.activity</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.GamificationIntegrationListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>kudos.cancel.activity</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.KudosCanceledListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
   <remove-configuration>org.exoplatform.commons.search.index.IndexingOperationProcessor</remove-configuration>
 </configuration>

--- a/kudos-webapps/package-lock.json
+++ b/kudos-webapps/package-lock.json
@@ -5055,9 +5055,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
@@ -112,12 +112,12 @@
     <component-plugin>
       <name>exo.kudos.activity</name>
       <set-method>addListener</set-method>
-      <type>org.exoplatform.kudos.listener.NewKudosSentNotificationListener</type>
+      <type>org.exoplatform.kudos.listener.KudosSentNotificationListener</type>
     </component-plugin>
     <component-plugin>
       <name>exo.kudos.sent</name>
       <set-method>addListener</set-method>
-      <type>org.exoplatform.kudos.listener.NewKudosSentActivityGeneratorListener</type>
+      <type>org.exoplatform.kudos.listener.KudosSentActivityGeneratorListener</type>
     </component-plugin>
     <component-plugin>
       <name>exo.kudos.activity</name>
@@ -128,6 +128,11 @@
       <name>kudos.cancel.activity</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.kudos.listener.GamificationIntegrationListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>kudos.cancel.activity</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.kudos.listener.KudosCanceledListener</type>
     </component-plugin>
   </external-component-plugins>
 


### PR DESCRIPTION
Prior to this change, the `receiveKudos` gamification achievement is considered as 'rejected due to activity deletion' instead of 'canceled' when canceling the kudos by the author. This change will avoid deleting the activity before switching gamification events to canceled to not switch it as 'rejected'.