### PR TITLE
feat: Disable double notification when recieving a Kudos - MEED-1650 - Meeds-io/meeds#576

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/activity/KudosActivityTypePlugin.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/activity/KudosActivityTypePlugin.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.kudos.activity;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.social.core.ActivityTypePlugin;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+
+public class KudosActivityTypePlugin extends ActivityTypePlugin {
+
+  private KudosService kudosService;
+
+  public KudosActivityTypePlugin(KudosService kudosService,
+                                 InitParams params) {
+    super(params);
+    this.kudosService = kudosService;
+  }
+
+  @Override
+  public boolean isEnableNotification(ExoSocialActivity activity, String username) {
+    if (StringUtils.isBlank(username)) {
+      return false;
+    } else {
+      Kudos kudos = this.kudosService.getKudosByActivityId(Long.parseLong(activity.getId().replace("comment", "")));
+      return kudos != null
+          && !StringUtils.equals(kudos.getReceiverId(), username)
+          && !StringUtils.equals(kudos.getSenderId(), username);
+    }
+  }
+
+}

--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/plugin/KudosActivityChildPlugin.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/plugin/KudosActivityChildPlugin.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.kudos.notification.plugin;
+
+import static org.exoplatform.kudos.service.utils.Utils.KUDOS_ACTIVITY_COMMENT_TYPE;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.plugin.AbstractNotificationChildPlugin;
+import org.exoplatform.commons.api.notification.service.template.TemplateContext;
+import org.exoplatform.commons.notification.template.TemplateUtils;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
+
+public class KudosActivityChildPlugin extends AbstractNotificationChildPlugin {
+
+  private KudosService kudosService;
+
+  public KudosActivityChildPlugin(KudosService kudosService, InitParams initParams) {
+    super(initParams);
+    this.kudosService = kudosService;
+  }
+
+  @Override
+  public String makeContent(NotificationContext ctx) {
+    NotificationInfo notification = ctx.getNotificationInfo();
+    if (notification == null) {
+      return "";
+    }
+
+    String activityId = notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey());
+    Kudos kudos = kudosService.getKudosByActivityId(Long.parseLong(activityId.replace("comment", "")));
+    if (kudos == null) {
+      return "";
+    }
+    TemplateContext templateContext = new TemplateContext(getId(), getLanguage(notification));
+    templateContext.put("MESSAGE", kudos.getMessage());
+    return TemplateUtils.processGroovy(templateContext);
+  }
+
+  @Override
+  public String getId() {
+    return KUDOS_ACTIVITY_COMMENT_TYPE;
+  }
+
+  @Override
+  public boolean isValid(NotificationContext ctx) {
+    return false;
+  }
+
+}

--- a/kudos-services/src/main/resources/notification/KudosActivity.gtmpl
+++ b/kudos-services/src/main/resources/notification/KudosActivity.gtmpl
@@ -1,0 +1,20 @@
+<%
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+   *
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+%>
+<span class="kudos-message">$MESSAGE</span>

--- a/kudos-services/src/test/java/org/exoplatform/kudos/activity/KudosActivityChildPluginTest.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/activity/KudosActivityChildPluginTest.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.kudos.activity;
+
+import static org.exoplatform.kudos.service.utils.Utils.KUDOS_ACTIVITY_COMMENT_TYPE;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.kudos.notification.plugin.KudosActivityChildPlugin;
+import org.exoplatform.kudos.service.KudosService;
+import org.exoplatform.kudos.test.BaseKudosTest;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KudosActivityChildPluginTest extends BaseKudosTest {
+
+  private static final long    KUDOS_BY_ACTIVITY_ID = 5l;
+
+  private static final String  KUDOS_MESSAGE        = "KUDOS_MESSAGE";
+
+  @Mock
+  private KudosService         kudosService;
+
+  @Mock
+  private InitParams           initParams;
+
+  @Mock
+  private NotificationContext  ctx;
+
+  @Mock
+  private NotificationInfo     notification;
+
+  @Mock
+  private Kudos                kudos;
+
+  @Test
+  public void testGetId() {
+    KudosActivityChildPlugin kudosActivityChildPlugin = new KudosActivityChildPlugin(kudosService, initParams);
+    assertEquals(KUDOS_ACTIVITY_COMMENT_TYPE, kudosActivityChildPlugin.getId());
+  }
+
+  @Test
+  public void testIsValid() {
+    KudosActivityChildPlugin kudosActivityChildPlugin = new KudosActivityChildPlugin(kudosService, initParams);
+    assertFalse(kudosActivityChildPlugin.isValid(null));
+  }
+
+  @Test
+  public void testMakeContent() {
+    KudosActivityChildPlugin kudosActivityChildPlugin = new KudosActivityChildPlugin(kudosService, initParams);
+    when(kudosService.getKudosByActivityId(KUDOS_BY_ACTIVITY_ID)).thenReturn(kudos);
+    when(kudos.getMessage()).thenReturn(KUDOS_MESSAGE);
+    when(ctx.getNotificationInfo()).thenReturn(notification);
+    when(notification.getValueOwnerParameter(SocialNotificationUtils.ACTIVITY_ID.getKey())).thenReturn(String.valueOf(KUDOS_BY_ACTIVITY_ID));
+
+    assertTrue(StringUtils.contains(kudosActivityChildPlugin.makeContent(ctx), KUDOS_MESSAGE));
+  }
+
+}

--- a/kudos-services/src/test/resources/conf/kudos-test-configuration.xml
+++ b/kudos-services/src/test/resources/conf/kudos-test-configuration.xml
@@ -52,5 +52,54 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
+    <!-- Kudos activity notification type -->
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addChildPlugin</set-method>
+      <type>org.exoplatform.kudos.notification.plugin.KudosActivityChildPlugin</type>
+      <description>Initial information for Kudos child notification plugin.</description>
+      <init-params>
+        <value-param>
+          <name>templatePath</name>
+          <value><![CDATA[classpath:/notification/KudosActivity.gtmpl]]></value>
+        </value-param>
+        <object-param>
+          <name>template.gamification.KudosActivity</name>
+          <description>The template of KudosActivityChildPlugin</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <!-- Activity Type name -->
+              <string>exokudos:activity</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.addon.Kudos</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
+    <component-plugin>
+      <name>NewsActivityTypePlugin</name>
+      <set-method>addActivityTypePlugin</set-method>
+      <type>org.exoplatform.kudos.activity.KudosActivityTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>type</name>
+          <value>exokudos:activity</value>
+        </value-param>
+        <value-param>
+          <name>enableNotification</name>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
   <remove-configuration>org.exoplatform.commons.search.index.IndexingOperationProcessor</remove-configuration>
 </configuration>

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
@@ -32,7 +32,32 @@
 
   <external-component-plugins>
     <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
-
+    <!-- Kudos activity notification type -->
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addChildPlugin</set-method>
+      <type>org.exoplatform.kudos.notification.plugin.KudosActivityChildPlugin</type>
+      <description>Initial information for Kudos child notification plugin.</description>
+      <init-params>
+        <value-param>
+          <name>templatePath</name>
+          <value><![CDATA[classpath:/notification/KudosActivity.gtmpl]]></value>
+        </value-param>
+        <object-param>
+          <name>template.gamification.KudosActivity</name>
+          <description>The template of KudosActivityChildPlugin</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <!-- Activity Type name -->
+              <string>exokudos:activity</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.addon.Kudos</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
     <!-- Kudos activity receiver notification plugin -->
     <component-plugin>
       <name>notification.plugins</name>
@@ -164,6 +189,25 @@
           </object-param>
         </init-params>
       </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.core.manager.ActivityManager</target-component>
+    <component-plugin>
+      <name>NewsActivityTypePlugin</name>
+      <set-method>addActivityTypePlugin</set-method>
+      <type>org.exoplatform.kudos.activity.KudosActivityTypePlugin</type>
+      <init-params>
+        <value-param>
+          <name>type</name>
+          <value>exokudos:activity</value>
+        </value-param>
+        <value-param>
+          <name>enableNotification</name>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>


### PR DESCRIPTION
This change will allow to reuse Activity Notifications for Kudos Activities and comment but not for the receiver who will get one single specific notification.