### PR TITLE
fix: Fix Kudos Sending outside of activities - MEED-2476 - Meeds-io/meeds#1090

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/entity/KudosEntity.java
@@ -76,7 +76,7 @@ public class KudosEntity implements Serializable {
   @Column(name = "IS_RECEIVER_USER", nullable = false)
   public boolean            isReceiverUser;
 
-  @Column(name = "PARENT_ENTITY_ID", nullable = false)
+  @Column(name = "PARENT_ENTITY_ID", nullable = true)
   public Long               parentEntityId;
 
   @Column(name = "ENTITY_ID", nullable = false)

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
@@ -202,6 +202,8 @@ public class Utils {
     kudosEntity.setActivityId(kudos.getActivityId());
     if (StringUtils.isNoneBlank(kudos.getParentEntityId())) {
       kudosEntity.setParentEntityId(Long.parseLong(kudos.getParentEntityId()));
+    } else {
+      kudosEntity.setParentEntityId(0l);
     }
     kudosEntity.setEntityType(KudosEntityType.valueOf(kudos.getEntityType()).ordinal());
     kudosEntity.setSenderId(Long.parseLong(kudos.getSenderIdentityId()));


### PR DESCRIPTION
Prior to this change, when sending a kudos outside of an activity, the Parent Entity Identifier is null while it was set as mandatory in Hibernate Entity Mapping. This change will ensure to use the exact same constraint as the ones made in database for this field, which is nullable.