### PR TITLE
feat: Add Notification Administration Label - MEED-2445 - Meeds-io/MIPs#79

### DIFF
--- a/kudos-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties
+++ b/kudos-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties
@@ -1,0 +1,1 @@
+NotificationAdmin.KudosActivityReceiverNotificationPlugin=A kudos has been sent

--- a/kudos-webapps/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
+++ b/kudos-webapps/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
@@ -1,0 +1,1 @@
+NotificationAdmin.KudosActivityReceiverNotificationPlugin=Un kudos a \u00E9t\u00E9 envoy\u00E9

--- a/translations.properties
+++ b/translations.properties
@@ -26,3 +26,4 @@ Kudos.properties=kudos-services/src/main/resources/locale/addon/Kudos_en.propert
 
 # Analytics
 Analytics.properties=kudos-webapps/src/main/resources/locale/portlet/Analytics_en.properties
+NotificationAdministration.properties=kudos-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties


### PR DESCRIPTION
Prior to this change, the notification label is displayed the same way in administration and user settings. This change will add a dedicated label when in administration scope.