### PR TITLE
fix: Align action labels below the composer - MEED-2609 -Meeds-io/MIP#54

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosComposer.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosComposer.vue
@@ -1,3 +1,19 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2023 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <v-card
     id="sendKudosComposerButton"

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
@@ -1,3 +1,19 @@
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2023 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <v-tooltip v-if="!spaceId" bottom>
     <template #activator="{ on, attrs }">
@@ -31,7 +47,7 @@
       color="primary">
       fa-award
     </v-icon>
-    <v-span class="body-2 font-weight-bold ms-5  mt-1 dark-grey-color">
+    <v-span class="body-2 font-weight-bold ms-5 dark-grey-color">
       {{ $t('kudos.title') }}
     </v-span>
   </v-btn>


### PR DESCRIPTION
This change will align action labels below the composer and add the license header for new components.