### PR TITLE
fix: Hide audience when sending kudos through an activity or a comment - MEED-2597 -Meeds-io/meeds#1136

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -42,7 +42,7 @@
                     include-users
                     name="kudosReceiver"
                     width="220"
-                    class="user-suggester" />
+                    class="user-suggester mb-2" />
                 </div>
                 <exo-user-avatar
                   v-else
@@ -165,7 +165,7 @@
               </v-list-item>
             </div>
             <exo-user-avatar
-              v-if="postInYourNetwork"
+              v-if="displaySenderAvatar"
               :profile-id="username"
               extra-class="text-truncate ms-2 me-1"
               link-style
@@ -398,10 +398,13 @@ export default {
       return this.postInYourSpacesChoice && !this.audience;
     },
     audienceTypesDisplay() {
-      return (!this.spaceId && !this.isLinkedKudos)  || (!this.spaceId && !this.readOnlySpace) || (!this.readOnlySpace  && this.postInYourSpacesChoice && !this.audience);
+      return (!this.spaceId && !this.isLinkedKudos) || (!this.spaceId && !this.readOnlySpace && !this.isLinkedKudos) || (!this.readOnlySpace  && this.postInYourSpacesChoice && !this.audience);
     },
     audienceAvatarDisplay() {
       return (this.audience && this.postInYourSpacesChoice) || this.readOnlySpace;
+    },
+    displaySenderAvatar() {
+      return this.postInYourNetwork || this.isLinkedKudos;
     }
   },
   methods: {


### PR DESCRIPTION
This change will hide audience when sending kudos through an activity or a comment.
