### PR TITLE
feat: Add SpaceId in Generated notifications to allow muting it - MEED-2598 - Meeds-io/MIPs#97

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/notification/plugin/KudosReceiverNotificationPlugin.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/notification/plugin/KudosReceiverNotificationPlugin.java
@@ -23,8 +23,11 @@ import java.util.List;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.kudos.model.Kudos;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 
 public class KudosReceiverNotificationPlugin extends BaseNotificationPlugin {
@@ -56,9 +59,15 @@ public class KudosReceiverNotificationPlugin extends BaseNotificationPlugin {
     if (toList == null || toList.isEmpty()) {
       return null;
     }
+    ActivityManager activityManager = ExoContainerContext.getService(ActivityManager.class);
+    ExoSocialActivity activity = activityManager.getActivity(String.valueOf(kudos.getActivityId()));
+    if (activity.isComment()) {
+      activity = activityManager.getActivity(activity.getParentId());
+    }
 
     return NotificationInfo.instance()
                            .to(toList)
+                           .setSpaceId(activity == null ? 0l : Long.parseLong(activity.getSpaceId()))
                            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), String.valueOf(kudos.getActivityId()))
                            .with("ENTITY_ID", kudos.getEntityId())
                            .with("ENTITY_TYPE", kudos.getEntityType())

--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/notification-configuration.xml
@@ -54,6 +54,9 @@
             <field name="bundlePath">
               <string>locale.addon.Kudos</string>
             </field>
+            <field name="mutable">
+              <boolean>false</boolean>
+            </field>
           </object>
         </object-param>
       </init-params>
@@ -89,6 +92,9 @@
             </field>
             <field name="bundlePath">
               <string>locale.notification.KudosNotification</string>
+            </field>
+            <field name="mutable">
+              <boolean>false</boolean>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
This change will allow to mute kudos notifications added to a space. For now, the muting is disabled, but the spaceId is attached into the notification for future possible modifications.