### PR TITLE
fix: Reset the audience field to empty after closing send kudos drawer - MEED-2801 - Meeds-io/meeds#1223

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -16,7 +16,7 @@
       id="activityKudosDrawer"
       right
       disable-pull-to-refresh
-      @closed="resetEditor">
+      @closed="closeDrawer">
       <template slot="title">
         <span class="text-header-title">
           {{ $t('exoplatform.kudos.title.sendAKudos') }}
@@ -453,7 +453,8 @@ export default {
           this.error = e;
         });
     },
-    resetEditor() {
+    closeDrawer() {
+      this.resetAudienceChoice();
       this.ckEditorInstance.destroyCKEditor();
     },
     initDrawer() {


### PR DESCRIPTION
This change will reset the audience field to empty after closing send kudos drawer.
