### PR TITLE
fix: Reset the audience field to empty after closing send kudos drawer - MEED-2801 - Meeds-io/meeds#1223

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -15,7 +15,7 @@
       id="activityKudosDrawer"
       right
       disable-pull-to-refresh
-      @closed="resetEditor">
+      @closed="closeDrawer">
       <template slot="title">
         <span class="text-header-title">
           {{ $t('exoplatform.kudos.title.sendAKudos') }}
@@ -449,7 +449,8 @@ export default {
           this.error = e;
         });
     },
-    resetEditor() {
+    closeDrawer() {
+      this.resetAudienceChoice();
       this.$refs[this.ckEditorId].destroyCKEditor();
     },
     initDrawer() {


### PR DESCRIPTION
This change will reset the audience field to empty after closing send kudos drawer.