### PR TITLE
fix: Fix Kudos Overview Display - MEED-2860 - Meeds-io/MIPs#104

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewRow.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverviewRow.vue
@@ -31,9 +31,6 @@
           </template> 
         </kudos-overview-card>
       </v-col>
-      <v-divider
-        class="my-9 mx-8 me-md-1 ms-md-5"
-        vertical />
       <v-col class="kudosOverviewCard">
         <kudos-overview-card
           :clickable="isOwner && sentKudosCount > 0"


### PR DESCRIPTION
This change will delete a useless divider between received and sent kudos which makes the kudos sections overflows in Mobile View