### PR TITLE
fix: Delete useless Mocked methods - MEED-1580 - Meeds-io/meeds#1428

### DIFF
--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/IdentityManagerMock.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/IdentityManagerMock.java
@@ -54,7 +54,6 @@ public class IdentityManagerMock implements IdentityManager {
     }
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getProviderId(), providerId)
@@ -63,7 +62,6 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public Identity getIdentity(String identityId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getId(), identityId))
@@ -71,77 +69,62 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public void registerIdentityProviders(IdentityProviderPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public void addProfileListener(ProfileListenerPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public Identity getIdentity(String providerId, String remoteId, boolean loadProfile) {
     return getOrCreateIdentity(providerId, remoteId, loadProfile);
   }
 
-  @Override
   public boolean identityExisted(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true) != null;
   }
 
-  @Override
   public Identity getIdentity(String id) {
     return getIdentity(id, true);
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true);
   }
 
-  @Override
   public Identity updateIdentity(Identity identity) {
     return identity;
   }
 
-  @Override
   public List<Identity> getLastIdentities(int limit) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void deleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void hardDeleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getConnectionsWithListAccess(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public Profile getProfile(Identity identity) {
     return identity.getProfile();
   }
 
-  @Override
   public InputStream getAvatarInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public InputStream getBannerInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void updateProfile(Profile specificProfile) {
     List<Profile.UpdateType> list = new ArrayList<>();
     if (specificProfile.getProperty(Profile.FIRST_NAME) != null || specificProfile.getProperty(Profile.POSITION) != null ) {
@@ -155,19 +138,16 @@ public class IdentityManagerMock implements IdentityManager {
     }
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesByProfileFilter(String providerId,
                                                            ProfileFilter profileFilter,
                                                            boolean isProfileLoaded) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesForUnifiedSearch(String providerId, ProfileFilter profileFilter) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getSpaceIdentityByProfileFilter(Space space,
                                                               ProfileFilter profileFilter,
                                                               Type type,
@@ -175,32 +155,26 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void addIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void removeIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListenerPlugin profileListenerPlugin) {
     profileLifeCycle.addListener(profileListenerPlugin);
   }
 
-  @Override
   public void processEnabledIdentity(String remoteId, boolean isEnable) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId,
                                                      ProfileFilter profileFilter,
                                                      long offset,
@@ -208,22 +182,18 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter, long offset, long limit) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId,
                                                       ProfileFilter profileFilter,
                                                       long offset,
@@ -231,87 +201,30 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public long getIdentitiesCount(String providerId) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public void saveIdentity(Identity identity) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void saveProfile(Profile profile) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void addOrModifyProfileProperties(Profile profile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateAvatar(Profile p) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateBasicInfo(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateContactSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateExperienceSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateHeaderSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId, boolean loadProfile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public List<Identity> getConnections(Identity ownerIdentity) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getIdentityStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListener listener) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void unregisterProfileListener(ProfileListener listener) {
     throw new UnsupportedOperationException();
   }

--- a/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/SpaceServiceMock.java
+++ b/kudos-services/src/test/java/org/exoplatform/kudos/test/mock/SpaceServiceMock.java
@@ -232,11 +232,6 @@ public class SpaceServiceMock implements SpaceService {
 
   }
 
-  public List<Space> getSpacesByFirstCharacterOfName(String firstCharacterOfName) throws SpaceException {
-    throw new UnsupportedOperationException();
-
-  }
-
   public List<Space> getSpacesBySearchCondition(String condition) throws Exception {
     throw new UnsupportedOperationException();
 
@@ -571,18 +566,6 @@ public class SpaceServiceMock implements SpaceService {
 
   public boolean isSuperManager(String userId) {
     return false;
-  }
-
-  public List<MembershipEntry> getSuperManagersMemberships() {
-    throw new UnsupportedOperationException();
-  }
-
-  public void addSuperManagersMembership(String permissionExpression) {
-    throw new UnsupportedOperationException();
-  }
-
-  public void removeSuperManagersMembership(String permissionExpression) {
-    throw new UnsupportedOperationException();
   }
 
 }


### PR DESCRIPTION
This change will delete  flag from Mocked Test classes to not have a compilation error when deleting or modifying a fake method implementation from IdentityManager and SpaceService. In addition, this will cleanup useless methods implemented in Mocked Social Classes.