### PR TITLE
Feat: Add default user avatar when hover on reciever user name - MEED-3111 - Meeds-io/MIPs#83

### DIFF
--- a/kudos-services/src/main/java/org/exoplatform/kudos/model/Kudos.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/model/Kudos.java
@@ -43,6 +43,8 @@ public class Kudos implements Serializable {
 
   private boolean           externalReceiver;
 
+  private boolean           enabledReceiver;
+
   private String            message;
 
   private long              timeInSeconds;

--- a/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
+++ b/kudos-services/src/main/java/org/exoplatform/kudos/service/utils/Utils.java
@@ -174,6 +174,7 @@ public class Utils {
       kudos.setExternalReceiver(receiverIdentity.getProfile() != null
           && receiverIdentity.getProfile().getProperty("external") != null
           && receiverIdentity.getProfile().getProperty("external").equals("true"));
+      kudos.setEnabledReceiver(receiverIdentity.isEnable() && !receiverIdentity.isDeleted());
       kudos.setReceiverFullName(receiverIdentity.getProfile().getFullName());
       kudos.setReceiverURL(LinkProvider.getUserProfileUri(receiverIdentity.getRemoteId()));
       kudos.setReceiverAvatar(getAvatar(receiverIdentity, null));

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -310,6 +310,7 @@ export function registerActivityActionExtension() {
             'avatar': kudos.receiverAvatar,
             'position': kudos.receiverPosition,
             'external': String(kudos.externalReceiver),
+            'enabled': String(kudos.enabledReceiver),
           };
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',


### PR DESCRIPTION
This change adds the user enabled property in identity-popover directive for kudos message, this property allows to display the new default user avatar instead of the old one.