### PR TITLE
feat: fix default avatar when sending kudos - MEED-3266 - Meeds-io/MIPs#83

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/KudosIdentity.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/KudosIdentity.js
@@ -67,6 +67,7 @@ export function getIdentityDetails(urlId, type, remoteId) {
               ownerDetails.username = identityDetails.username;
               ownerDetails.position = identityDetails.position;
               ownerDetails.external = identityDetails.external;
+              ownerDetails.enabled = identityDetails.enabled;
             } else {
               ownerDetails.notAuthorized = true;
             }


### PR DESCRIPTION
Prior to this change, the generated default avatar is not displayed in the send kudos drawer for the receiver avatar. This change allows to add the user enabled property information to then receiver details to display the default avatar is the user is enabled.