### PR TITLE
feat: Fix activity kudos reaction display when large screen - MEED-3361 - Meeds-io/MIPs#113

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="!isComment && 'ms-lg-4'"
+    :class="!isComment && 'ms-xl-4 ms-lg-3'"
     class="d-inline-flex">
     <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
@@ -28,7 +28,7 @@
                   :size="isMobile && '20' || '14'">
                   fa-award
                 </v-icon>
-                <span v-if="!isMobile" class="mx-auto mt-1 mt-lg-0 ms-lg-2">
+                <span v-if="!isMobile" class="mx-auto mt-1 mt-lg-0 ms-lg-1">
                   {{ $t('exoplatform.kudos.label.kudos') }}
                 </span>
               </div>


### PR DESCRIPTION
This PR allows to reduce the spacing in the activity kudos action to prevent it from moving to a new line when the screen width is between 1264px and 1364px.