### PR TITLE
fix: fix displaying kudos number selector - EXO-69894 - Meeds-io/meeds#1774

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
@@ -25,7 +25,7 @@
       {{ $t('kudos.administration.label') }}
     </div>
     <div class="d-flex flex-row kudosPeriodConfiguration">
-      <div class="flex-grow-1 flex-shrink-1">
+      <div class="flex-grow-1 flex-shrink-1 col-2 pa-0">
         <v-text-field
           v-model="kudosPerPeriod"
           type="number"
@@ -43,7 +43,7 @@
         <select
           id="applicationToolbarFilterSelect"
           v-model="kudosPeriodType"
-          class="ignore-vuetify-classes my-auto">
+          class="ignore-vuetify-classes my-auto col-12 py-0">
           <option
             v-for="item in periods"
             :key="item.value"


### PR DESCRIPTION
before this change,a bad display of  the number of kudos per period so It's impossible to indicate and modify it
After this change, the UI issue is fixed and the number of kudos per period is well displayed 

