### PR TITLE
fix: fix displaying kudos number selector - EXO-69894 - Meeds-io/meeds#1774

### DIFF
--- a/kudos-packaging/pom.xml
+++ b/kudos-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>2.6.x-exo-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-packaging</artifactId>
   <packaging>pom</packaging>

--- a/kudos-services/pom.xml
+++ b/kudos-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>2.6.x-exo-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-services</artifactId>
   <name>eXo Add-on:: eXo Kudos - Services</name>

--- a/kudos-webapps/pom.xml
+++ b/kudos-webapps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>2.6.x-exo-SNAPSHOT</version>
+    <version>2.6.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-webapps</artifactId>
   <packaging>war</packaging>

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
@@ -25,7 +25,7 @@
       {{ $t('kudos.administration.label') }}
     </div>
     <div class="d-flex flex-row kudosPeriodConfiguration">
-      <div class="flex-grow-1 flex-shrink-1 col-2 pa-0">
+      <div class="flex-grow-1 flex-shrink-1">
         <v-text-field
           v-model="kudosPerPeriod"
           type="number"
@@ -43,7 +43,7 @@
         <select
           id="applicationToolbarFilterSelect"
           v-model="kudosPeriodType"
-          class="ignore-vuetify-classes my-auto col-12 py-0">
+          class="ignore-vuetify-classes my-auto">
           <option
             v-for="item in periods"
             :key="item.value"

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-admin/components/settings/AdminForm.vue
@@ -25,7 +25,7 @@
       {{ $t('kudos.administration.label') }}
     </div>
     <div class="d-flex flex-row kudosPeriodConfiguration">
-      <div class="flex-grow-1 flex-shrink-1">
+      <div class="flex-grow-1 flex-shrink-1 col-2 pa-0">
         <v-text-field
           v-model="kudosPerPeriod"
           type="number"
@@ -43,7 +43,7 @@
         <select
           id="applicationToolbarFilterSelect"
           v-model="kudosPeriodType"
-          class="ignore-vuetify-classes my-auto">
+          class="ignore-vuetify-classes my-auto col-12 py-0">
           <option
             v-for="item in periods"
             :key="item.value"

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.exoplatform.addons.kudos</groupId>
   <artifactId>kudos</artifactId>
-  <version>2.6.x-exo-SNAPSHOT</version>
+  <version>2.6.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Kudos - Parent POM</name>
   <description>eXo Kudos Addon</description>
@@ -27,9 +27,9 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.6.x-exo-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.6.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.analytics.version>1.5.x-exo-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.social.version>6.6.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.6.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.analytics.version>1.5.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
 
     <!-- **************************************** -->
     <!-- Jenkins Settings -->


### PR DESCRIPTION
before this change, a bad display of the number of kudos per period so It's impossible to indicate and modify it After this change, the UI issue is fixed, and the number of kudos per period is well-displayed