### PR TITLE
feat: Add can collapse option to kudos activity extension - MEED-4539-Meeds-io/MIPs#124

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -335,6 +335,7 @@ export function registerActivityActionExtension() {
       noSummaryEllipsis: true,
       supportsIcon: true,
       useSameViewForMobile: true,
+      isCollapsed: true,
       getDefaultIcon: (activityOrComment) => ({
         icon: 'fa fa-award primary--text',
         size: activityOrComment.activityId && 37 || 72,


### PR DESCRIPTION
This PR allows to add a new option the the kudos activity type extension to check if it is collapsed or not.