### PR TITLE
fix: Avoid initialize kudos api when accessing public site - MEED-6225 - Meeds-io/meeds#1905

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -275,7 +275,8 @@ export default {
       spaceId: eXo.env.portal.spaceId,
       spacePrettyName: eXo.env.portal.spaceName,
       audienceChoice: null,
-      noReceiverIdentityId: false
+      noReceiverIdentityId: false,
+      isPublicSite: eXo.env.portal.portalName === 'public',
     };
   },
   watch: {
@@ -323,15 +324,16 @@ export default {
     }
   },
   created() {
-    this.init()
-      .then(() => {
-        if (this.disabled) {
-          return;
-        }
-        this.$refs.kudosAPI.init();
-
-        document.addEventListener('exo-kudos-open-send-modal', this.openDrawer);
-      });
+    if (!this.isPublicSite) {
+      this.init()
+        .then(() => {
+          if (this.disabled) {
+            return;
+          }
+          this.$refs.kudosAPI.init();
+          document.addEventListener('exo-kudos-open-send-modal', this.openDrawer);
+        });
+    }
   },
   computed: {
     searchOptions() {


### PR DESCRIPTION
Before this change, errors were listed when accessing the public site linked to the Kudos API