### PR TITLE
fix: Avoid initialize kudos api when accessing public site - MEED-6225 - Meeds-io/meeds#1905

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -323,15 +323,16 @@ export default {
     }
   },
   created() {
-    this.init()
-      .then(() => {
-        if (this.disabled) {
-          return;
-        }
-        this.$refs.kudosAPI.init();
-
-        document.addEventListener('exo-kudos-open-send-modal', this.openDrawer);
-      });
+    if (eXo?.env?.portal?.userName) {
+      this.init()
+        .then(() => {
+          if (this.disabled) {
+            return;
+          }
+          this.$refs.kudosAPI.init();
+          document.addEventListener('exo-kudos-open-send-modal', this.openDrawer);
+        });
+    }
   },
   computed: {
     searchOptions() {


### PR DESCRIPTION
Before this change, errors were listed when accessing the public site linked to the Kudos API