### PR TITLE
feal: Display last comments on kudos activity - MEED-4546 - Meeds-io/MIPs#124

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -1,9 +1,5 @@
 const kudosListByActivity = {};
 
-const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
-const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
-defaultActivityOptions.displayLastCommentsRequiredActions.push('KudosActivityReceiverNotification');
-
 export function resetActivityKudosList(activity) {
   delete activity.kudosList;
   delete kudosListByActivity[activity.id];
@@ -356,9 +352,13 @@ export function registerActivityActionExtension() {
         }
       },
       canEdit: activityOrComment => activityOrComment.identity.id === eXo.env.portal.userIdentityId,
-      forceCanEditOverwrite: true,
-      displayLastCommentsRequiredActions: defaultActivityOptions.displayLastCommentsRequiredActions,
+      forceCanEditOverwrite: true
     },
+  });
+
+  extensionRegistry.registerExtension('activity', 'expand-action-type', {
+    id: 'KudosActivityReceiverNotification',
+    rank: 30,
   });
 
   extensionRegistry.registerExtension('activity', 'action', {

--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -1,5 +1,9 @@
 const kudosListByActivity = {};
 
+const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
+const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
+defaultActivityOptions.displayLastCommentsRequiredActions.push('KudosActivityReceiverNotification');
+
 export function resetActivityKudosList(activity) {
   delete activity.kudosList;
   delete kudosListByActivity[activity.id];
@@ -353,6 +357,7 @@ export function registerActivityActionExtension() {
       },
       canEdit: activityOrComment => activityOrComment.identity.id === eXo.env.portal.userIdentityId,
       forceCanEditOverwrite: true,
+      displayLastCommentsRequiredActions: defaultActivityOptions.displayLastCommentsRequiredActions,
     },
   });
 


### PR DESCRIPTION
This PR allows to add kudos receiver action type to the list of required actions to display the last two comments in activity.