### PR TITLE
feal: Display last comments on kudos activity - MEED-4546 - Meeds-io/MIPs#124

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -352,8 +352,13 @@ export function registerActivityActionExtension() {
         }
       },
       canEdit: activityOrComment => activityOrComment.identity.id === eXo.env.portal.userIdentityId,
-      forceCanEditOverwrite: true,
+      forceCanEditOverwrite: true
     },
+  });
+
+  extensionRegistry.registerExtension('activity', 'expand-action-type', {
+    id: 'KudosActivityReceiverNotification',
+    rank: 30,
   });
 
   extensionRegistry.registerExtension('activity', 'action', {


### PR DESCRIPTION
This PR allows to add kudos receiver action type to the list of required actions to display the last two comments in activity.