### PR TITLE
fix: Fix Application Border Radius - MEED-6880 - Meeds-io/meeds#2015

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
@@ -1,7 +1,6 @@
 <template>
   <v-app
-    :class="owner && 'kudosOverviewApplication' || 'kudosOverviewApplicationOther'"
-    class="white">
+    :class="owner && 'kudosOverviewApplication' || 'kudosOverviewApplicationOther'">
     <widget-wrapper
       id="kudosOverviewHeader"
       :title="$t('exoplatform.kudos.button.rewardedKudos')">


### PR DESCRIPTION
Prior to this change, profile page widgets was displayed without border radius as defined in Branding. This change deletes the 'white' class introduced on application main element to let the application display inherit the border radius as defined in branding using 'card-border-radius'.