### PR TITLE
fix: disable kudos button in the user card for logged-in user - Meeds-io/meeds#2197 - EXO-71739

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -194,7 +194,7 @@ export function registerExternalExtensions(title) {
     class: 'fas fa-award',
     additionalClass: 'mt-1',
     order: 50,
-    enabled: (profile) => profile.enabled && !profile.deleted,
+    enabled: (profile) => profile.enabled && !profile.deleted && profile.username !== eXo.env.portal.userName,
     click: (profile) => {
       const type = profile.prettyName ? 'SPACE_PROFILE' : 'USER_PROFILE';
       const id = profile.prettyName ? profile.id : profile.username;


### PR DESCRIPTION
This fix will disable the kudos button in the user card for the logged in user