### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -28,6 +28,10 @@
        <name>preload.resource.rest</name>
        <value><![CDATA[/kudos/rest/account/settings,/kudos/rest/settings]]></value>
      </init-param>
+     <init-param>
+       <name>layout-css-class</name>
+       <value>no-layout-style</value>
+     </init-param>
      <expiration-cache>-1</expiration-cache>
      <cache-scope>PUBLIC</cache-scope>
      <supports>

--- a/kudos-webapps/src/main/webapp/vue-app/connectorEventExtensions/components/KudosEvent.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/connectorEventExtensions/components/KudosEvent.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app v-if="!isEditing">
+  <div v-if="!isEditing">
     <div class="subtitle-1 font-weight-bold mb-2">
       {{ $t('gamification.event.display.doItNow') }}
     </div>
@@ -29,7 +29,7 @@
         {{ $t('gamification.event.display.congratulate') }}
       </v-btn>
     </div>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos-overview/components/KudosOverview.vue
@@ -3,7 +3,8 @@
     :class="owner && 'kudosOverviewApplication' || 'kudosOverviewApplicationOther'">
     <widget-wrapper
       id="kudosOverviewHeader"
-      :title="$t('exoplatform.kudos.button.rewardedKudos')">
+      :title="$t('exoplatform.kudos.button.rewardedKudos')"
+      extra-class="application-body">
       <template #action>
         <select
           v-model="periodType"


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.