### PR TITLE
fix: Avoid error message display on page display when session timeout - MEED-7171 - Meeds-io/meeds#2249

### DIFF
--- a/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
+++ b/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
@@ -103,3 +103,5 @@ kudos.administration.label=Decide number of kudos available for a period
 kudos.administration.apply=Apply
 kudos.administration.cancel=Cancel
 kudos.administration.reset=Reset
+
+kudos.unkownErrorWhileRetrievingSettings=An unknown error happened while retrieving kudos settings. Please try again later or contact the administrator.

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -455,9 +455,7 @@ export default {
               this.allKudosSent = allKudos && allKudos.kudos || [];
             });
         })
-        .catch(e => {
-          this.error = e;
-        });
+        .catch(e => console.debug(e));
     },
     closeDrawer() {
       this.resetAudienceChoice();
@@ -533,7 +531,7 @@ export default {
             this.entityOwner = null;
           })
           .catch(e => {
-            this.error = String(e);
+            this.error = this.$te(e?.message) ? this.$t(e.message) : this.$t('kudos.unkownErrorWhileRetrievingSettings');
             console.error('Error retrieving entity details with type and id', this.entityType, this.entityId, e);
           });
       }


### PR DESCRIPTION
Prior to this change, when displaying a page while the session timed out, an alert message is displayed. This change ensures to display the alert message only when the user makes an action on Kudos module and not on loading time.

Resolves Meeds-io/meeds/issues/2249