### PR TITLE
fix: Fix Space URL computing using new Web Controller Handler - MEED-7568 - Meeds-io/MIPs#158

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/Kudos.js
@@ -344,7 +344,7 @@ export function registerActivityActionExtension() {
             enabled: String(kudos.enabledReceiver),
             identityType: kudos.receiverType,
           };
-          const url = kudos.receiverType === 'user' ? `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${kudos.receiverId}` : `${eXo.env.portal.context}/s/${kudos.technicalId}`;
+          const url = kudos.receiverType === 'user' ? `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/profile/${kudos.receiverId}` : `${eXo.env.portal.context}/s/${kudos.receiverIdentityId}`;
           return {
             key: 'NewKudosSentActivityComment.activity_kudos_title',
             params: {


### PR DESCRIPTION
This change will fix the space referenced in Kudos, to use Space Id instead of Kudos Id in Built URL