### PR TITLE
feat: Delete Primary Color for Kudos Button in Space Popover - MEED-7617 - Meeds-io/meeds#2473

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/PopoverKudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/PopoverKudosButton.vue
@@ -8,7 +8,6 @@
           <v-btn
             :ripple="false"
             icon
-            color="primary"
             @click="sendKudos($event)">
             <v-icon size="18">fa-award</v-icon>
           </v-btn>


### PR DESCRIPTION
This change will harmonize Space Actions Color by deleting the Primary color on Kudos icon in:
- Space Topbar Popover
- Space Popover
- Space Left Menu Quick actions.