### PR TITLE
fix: Fix Autofill Space in Kudos Drawer - MEED-7630 - Meeds-io/meeds#2481

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/js/KudosIdentity.js
+++ b/kudos-webapps/src/main/webapp/vue-app/js/KudosIdentity.js
@@ -81,7 +81,8 @@ export function getIdentityDetails(urlId, type, remoteId) {
             return ownerDetails;
           });
       } else {
-        return fetch(`/portal/rest/v1/social/spaces/byPrettyName/${urlId}`, {credentials: 'include'})
+        const url = Number.isFinite(Number(urlId)) ? `/portal/rest/v1/social/spaces/${urlId}` : `/portal/rest/v1/social/spaces/byPrettyName/${urlId}`;
+        return fetch(url, {credentials: 'include'})
           .then((resp) => resp && resp.ok && resp.json())
           .then((identityDetails) => {
             if (identityDetails) {


### PR DESCRIPTION
Prior to this change, when using Kudos button on Popover, the space isn't auto-filled. This due the fact that the Space is retrieved using Technical identifier rather than the pretty name. This change will allow to retrieve the space by both types of identifier.