### PR TITLE
feat: Compute Kudos properties instead of relying on given parameters in HTTP call - MEED-7636 - Meeds-io/meeds#2485

### DIFF
--- a/kudos-services/src/main/java/io/meeds/kudos/service/KudosService.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/service/KudosService.java
@@ -207,17 +207,25 @@ public class KudosService {
       throw new IllegalAccessException("User having username'" + currentUser + "' is not authorized to send more kudos");
     }
 
-    if (kudos.getSenderIdentityId() == null) {
-      kudos.setSenderIdentityId(senderIdentity.getId());
-    }
+    kudos.setSenderId(senderIdentity.getRemoteId());
+    kudos.setSenderIdentityId(senderIdentity.getId());
     Object receiverObject = checkStatusAndGetReceiver(kudos.getReceiverType(), kudos.getReceiverId());
 
     if (kudos.getReceiverIdentityId() == null) {
-      if (receiverObject instanceof Identity identity) {
+      if (receiverObject instanceof Identity identity && identity.isUser()) {
+        kudos.setReceiverId(identity.getRemoteId());
+        kudos.setReceiverType(USER_ACCOUNT_TYPE);
         kudos.setReceiverIdentityId(identity.getId());
+      } else if (receiverObject instanceof Identity identity && identity.isSpace()) {
+        Space space = getSpace(identity.getRemoteId());
+        kudos.setReceiverIdentityId(space.getId());
+        kudos.setReceiverId(space.getPrettyName());
+        kudos.setReceiverType(SPACE_ACCOUNT_TYPE);
       } else if (receiverObject instanceof Space space) {
         if (canSendKudosInSpace(kudos, space, currentUser)) {
+          kudos.setReceiverId(space.getPrettyName());
           kudos.setReceiverIdentityId(space.getId());
+          kudos.setReceiverType(SPACE_ACCOUNT_TYPE);
         } else {
           throw new IllegalAccessException("User cannot redact on space");
         }


### PR DESCRIPTION
Prior to this change, when sending a kudos to a user or space using an id instead of remoteId, the Kudos creation succeeds while the activity generation fails. This change ensures to store in kudos attributes the right value for Kudos fields and to not rely on properties sent with kudos object as is which will ensure data consistency.