### PR TITLE
fix: Fix Display of Kudos List from Oveview Widget - MEED-7741 - Meeds-io/meeds#2559 - Meeds-io/meeds#1768

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -216,6 +216,7 @@
             {{ $t('Confirmation.label.Cancel') }}
           </v-btn>
           <v-btn
+            :loading="sending"
             :disabled="sendButtonDisabled"
             :aria-label="$t('exoplatform.kudos.button.send')"
             class="btn btn-primary me-2"
@@ -263,6 +264,7 @@ export default {
       kudosToSend: null,
       kudosMessage: '',
       kudosPeriodType: '',
+      sending: false,
       loading: false,
       requiredField: false,
       identity: null,
@@ -601,6 +603,7 @@ export default {
         );
     },
     openDrawer(event) {
+      this.sending = false;
       if (!this.disabled) {
         if (this.remainingKudos > 0) {
           this.loading = true;
@@ -679,6 +682,7 @@ export default {
         spacePrettyName: (this.audience?.providerId === 'space' && this.audience?.remoteId)
           || this.spacePrettyName || null,
       };
+      this.sending = true;
       sendKudos(kudos)
         .then(kudosSent => {
           if (!kudosSent) {
@@ -713,6 +717,7 @@ export default {
           this.error = String(e);
         })
         .finally(() => {
+          window.setTimeout(() => this.sending = false, 200);
           this.$refs.drawer.endLoading();
         });
     },

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/KudosOverviewDrawer.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/KudosOverviewDrawer.vue
@@ -51,6 +51,7 @@
             v-if="tabName === 'sent'"
             :identity-id="identityId"
             :limit="limit"
+            :period-type="periodType"
             kudos-type="sent"
             @has-more="hasMore = $event"
             @loading="loading = $event" />
@@ -62,6 +63,7 @@
             v-if="tabName === 'received'"
             :identity-id="identityId"
             :limit="limit"
+            :period-type="periodType"
             kudos-type="received"
             @has-more="hasMore = $event"
             @loading="loading = $event" />
@@ -86,6 +88,7 @@
 export default {
   data: () => ({
     identityId: null,
+    periodType: null,
     tabName: null,
     drawer: false,
     loading: false,

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/KudosOverviewItemList.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/common/KudosOverviewItemList.vue
@@ -44,6 +44,10 @@ export default {
       type: String,
       default: null,
     },
+    periodType: {
+      type: String,
+      default: null,
+    },
     kudosType: {
       type: String,
       default: null,


### PR DESCRIPTION
Prior to this change, the list of received/sent Kudos was retrieved with an empty period which will retrieve the configured default period (WEEK). This change ensures to propagate the periodType into the list of Kudos to display in order to fix the listing. At the same time, this will fix a glich on sending kudos button to add a loading effect.