### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/kudos-services/src/main/resources/db/changelog/kudos-rdbms.db.changelog-1.0.0.xml
+++ b/kudos-services/src/main/resources/db/changelog/kudos-rdbms.db.changelog-1.0.0.xml
@@ -9,6 +9,7 @@
   <property name="autoIncrement" value="false" dbms="oracle,postgresql"/>
 
   <changeSet author="kudos" id="1.0.0-1">
+    <validCheckSum>9:39870c50d823de3ce569de2bd02d31a4</validCheckSum>
     <createTable tableName="ADDONS_KUDOS">
       <column name="KUDOS_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_ADDONS_KUDOS"/>
@@ -24,7 +25,7 @@
       <column name="CREATED_DATE" type="BIGINT"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -99,6 +100,11 @@
 
   <changeSet author="kudos" id="1.0.0-9" dbms="hsqldb">
     <createSequence sequenceName="SEQ_ADDONS_KUDOS_ID" startValue="1"/>
+  </changeSet>
+  <changeSet author="kudos" id="1.0.0-10" >
+    <sql dbms="mysql">
+      ALTER TABLE ADDONS_KUDOS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
   </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
