### PR TITLE
fix: It's possible to set message visibility to 'Your network' when exo.feature.PostToNetwork.enabled is set to false - EXO-75422 - Meeds-io/meeds#2606

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -87,6 +87,7 @@
             <div v-if="audienceTypesDisplay" class="pt-4">
               <span class="subtitle-1 text-color"> {{ $t('exoplatform.kudos.visibility.title') }} </span>
               <v-radio-group
+                v-if="postToNetwork"
                 v-model="audienceChoice"
                 class="mt-0 mb-7"
                 mandatory>
@@ -274,7 +275,8 @@ export default {
       username: eXo.env.portal.userName,
       spaceId: eXo.env.portal.spaceId,
       spacePrettyName: eXo.env.portal.spaceName,
-      audienceChoice: null,
+      postToNetwork: eXo.env.portal.postToNetworkEnabled,
+      audienceChoice: eXo.env.portal.postToNetworkEnabled && 'yourNetwork' ||  'oneOfYourSpaces',
       noReceiverIdentityId: false
     };
   },


### PR DESCRIPTION
Prior to this change, a user can set set message visibility to 'Your network' when sending a kudo even if the exo.feature.PostToNetwork.enabled is set to false. This commit hide the "Your network" option when the exo.feature.PostToNetwork.enabled is set to false in the Kudos drawer.