### PR TITLE
feat: Rename System Addon Container Extension to use it as UIPortalApplication extension - MEED-8281 - Meeds-io/MIPs#175

### DIFF
--- a/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/dynamic-container-configuration.xml
+++ b/kudos-webapps/src/main/webapp/WEB-INF/conf/kudos/dynamic-container-configuration.xml
@@ -14,7 +14,7 @@
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>bottom-all-container</value>
+          <value>body-end-container</value>
         </value-param>
         <object-param>
           <name>kudos-portlet</name>


### PR DESCRIPTION
This change will allow to centralize the **system Kudos app** to be served by `UIPortalApplication` extension rather than AddonContainers added inside the `sharedlayout.xml` and `portal.xml` of standalone sites.