### PR TITLE
fix: Prevent the audience suggester from appearing when sending kudos in an activity - MEED-8698 - Meeds-io/meeds#3177

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -452,7 +452,7 @@ export default {
     audienceTypesDisplay() {
       return (!this.spaceId && !this.isLinkedKudos)
         || (!this.spaceId && !this.readOnlySpace && !this.isLinkedKudos)
-        || (!this.readOnlySpace  && this.postInYourSpacesChoice && !this.audience)
+        || (!this.readOnlySpace  && this.postInYourSpacesChoice && this.spaceId)
         || (!this.isLinkedKudos && !this.noReceiverIdentityId && !this.audienceAvatarDisplay);
     },
     displaySenderAvatar() {

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosApp.vue
@@ -395,7 +395,7 @@ export default {
     sendButtonDisabled() {
       return !this.kudosMessageText|| this.kudosMessageTextLength > this.MESSAGE_MAX_LENGTH
         || this.kudosMessageValidityLabel
-        || (this.postInYourSpacesChoice && !this.audience)
+        || (this.postInYourSpacesChoice && this.spaceId && !this.audience)
         || (this.noReceiverIdentityId && !this.selectedReceiver);
     },
     remainingPeriodLabel() {
@@ -452,7 +452,7 @@ export default {
     audienceTypesDisplay() {
       return (!this.spaceId && !this.isLinkedKudos)
         || (!this.spaceId && !this.readOnlySpace && !this.isLinkedKudos)
-        || (!this.readOnlySpace  && this.postInYourSpacesChoice && this.spaceId)
+        || (!this.readOnlySpace  && this.postInYourSpacesChoice && this.spaceId && !this.audience)
         || (!this.isLinkedKudos && !this.noReceiverIdentityId && !this.audienceAvatarDisplay);
     },
     displaySenderAvatar() {


### PR DESCRIPTION
Prior to this change, the audience suggester was displayed when sending kudos to a user in an activity. This issue was due to an incorrect compute of the audience type display. This change correctly computes this property
Resolves https://github.com/Meeds-io/meeds/issues/3177