### PR TITLE
fix: Stream & News-details- User reactions Information are given only by color - MEED-8932 - Meeds-io/meeds#2985. 

### DIFF
--- a/kudos-packaging/pom.xml
+++ b/kudos-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.meeds.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>7.1.x-exo-SNAPSHOT</version>
+    <version>7.1.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-packaging</artifactId>
   <packaging>pom</packaging>

--- a/kudos-services/pom.xml
+++ b/kudos-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.meeds.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>7.1.x-exo-SNAPSHOT</version>
+    <version>7.1.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-services</artifactId>
   <name>Meeds:: Add-on:: eXo Kudos - Services</name>

--- a/kudos-webapps/pom.xml
+++ b/kudos-webapps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.meeds.kudos</groupId>
     <artifactId>kudos</artifactId>
-    <version>7.1.x-exo-SNAPSHOT</version>
+    <version>7.1.x-experience-SNAPSHOT</version>
   </parent>
   <artifactId>kudos-webapps</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>io.meeds.kudos</groupId>
   <artifactId>kudos</artifactId>
-  <version>7.1.x-exo-SNAPSHOT</version>
+  <version>7.1.x-experience-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Meeds:: Add-on:: Kudos - Parent POM</name>
   <description>Meeds Kudos Addon</description>
@@ -27,9 +27,9 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <io.meeds.social.version>7.1.x-exo-SNAPSHOT</io.meeds.social.version>
-    <io.meeds.platform-ui.version>7.1.x-exo-SNAPSHOT</io.meeds.platform-ui.version>
-    <addon.meeds.analytics.version>7.1.x-exo-SNAPSHOT</addon.meeds.analytics.version>
+    <io.meeds.social.version>7.1.x-experience-SNAPSHOT</io.meeds.social.version>
+    <io.meeds.platform-ui.version>7.1.x-experience-SNAPSHOT</io.meeds.platform-ui.version>
+    <addon.meeds.analytics.version>7.1.x-experience-SNAPSHOT</addon.meeds.analytics.version>
 
     <!-- **************************************** -->
     <!-- Jenkins Settings -->


### PR DESCRIPTION
Before this change, when Access to Stream (or an article), User reactions on a post (or articles) and post's comments (or articles' comments) are indicated only by a change in color of the reaction icons (Like, Comment, Kudos and Share). To fix this problem, add an aria-label to these buttons. After this change, add an aria-label attributes to the likeButton with a text You liked, the commentButton with a text You commented, the kudosButton with a text You sent a kudos and the shareButton with a text You sent a kudos.
Resolves https://github.com/Meeds-io/meeds/issues/2985