### PR TITLE
fix: Stream & News-details- User reactions Information are given only by color - MEED-8932 - Meeds-io/meeds#2985

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -6,14 +6,18 @@
       <template #activator="{ on, attrs }">
         <div
           class="d-flex"
-          v-bind="attrs"
+          v-bind="{
+              ...attrs,
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null}"
           v-on="on">
           <v-btn
             :id="`KudosActivity${entityId}`"
             :class="textColorClass"
             :x-small="isComment"
             :small="!isComment"
-            :aria-label="$t('kudos.aria.kudos')"
+            :aria-label="hasSentKudos ? $t('kudos.aria.kudos'): $t('exoplatform.kudos.label.kudos')"
             class="pa-0 mt-0"
             text
             link


### PR DESCRIPTION
Before this change, when Access to Stream (or an article), User reactions on a post (or articles) and post's comments (or articles' comments) are indicated only by a change in color of the reaction icons (Like, Comment, Kudos and Share). To fix this problem, add an aria-label to these buttons. After this change, add an aria-label attributes to the likeButton with a text You liked, the commentButton with a text You commented, the kudosButton with a text You sent a kudos and the shareButton with a text You sent a kudos. Resolves https://github.com/Meeds-io/meeds/issues/2985
