### PR TITLE
fix: Stream & News-details- User reactions Information are given only by color - MEED-8932 - Meeds-io/meeds#2985

### DIFF
--- a/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
+++ b/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
@@ -5,6 +5,7 @@ NewKudosSentActivityComment.activity_kudos=<i class="uiIcon fa fa-award uiIconKu
 NewKudosSentActivityComment.activity_kudos_content={3} Kudos to {1} {2}
 NewKudosSentActivityComment.activity_kudos_title=Kudos to {0}
 
+kudos.aria.kudos=You sent a kudos
 kudos.title=Kudos
 exoplatform.kudos.tooltip=Send Kudos
 exoplatform.kudos.title.sendAKudos=Send a Kudos

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -13,6 +13,7 @@
             :class="textColorClass"
             :x-small="isComment"
             :small="!isComment"
+            :aria-label="$t('kudos.aria.kudos')"
             class="pa-0 mt-0"
             text
             link

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -6,14 +6,18 @@
       <template #activator="{ on, attrs }">
         <div
           class="d-flex"
-          v-bind="attrs"
+          v-bind="{
+              ...attrs,
+              role: null,
+              'aria-haspopup': null,
+              'aria-expanded': null}"
           v-on="on">
           <v-btn
             :id="`KudosActivity${entityId}`"
             :class="textColorClass"
             :x-small="isComment"
             :small="!isComment"
-            :aria-label="$t('kudos.aria.kudos')"
+            :aria-label="hasSentKudos ? $t('kudos.aria.kudos'): $t('exoplatform.kudos.label.kudos')"
             class="pa-0 mt-0"
             text
             link


### PR DESCRIPTION
Before this change, when Access to Stream (or an article), User reactions on a post (or articles) and post's comments (or articles' comments) are indicated only by a change in color of the reaction icons (Like, Comment, Kudos and Share). To fix this problem, add an aria-label to these buttons. After this change, add an aria-label attributes to the likeButton with a text You liked, the commentButton with a text You commented, the kudosButton with a text You sent a kudos and the shareButton with a text You sent a kudos. 
Resolves https://github.com/Meeds-io/meeds/issues/2985
