### PR TITLE
fix: Incorrect aria-label rendering - MEED-9866 - meeds-io/meeds#375

### DIFF
--- a/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
+++ b/kudos-services/src/main/resources/locale/addon/Kudos_en.properties
@@ -5,6 +5,7 @@ NewKudosSentActivityComment.activity_kudos=<i class="uiIcon fa fa-award uiIconKu
 NewKudosSentActivityComment.activity_kudos_content={3} Kudos to {1} {2}
 NewKudosSentActivityComment.activity_kudos_title=Kudos to {0}
 
+kudos.aria.kudos=You sent a kudos
 kudos.title=Kudos
 exoplatform.kudos.tooltip=Send Kudos
 exoplatform.kudos.title.sendAKudos=Send a Kudos


### PR DESCRIPTION
before this change, when Create an article then publish it in the stream then send a kudos on it, The aria-labels of Send a kudo icons is incorrectly rendered. To fix this problem, add the key in the properties. After this change, The aria-label is correctly rendered.