### PR TITLE
fix: Improve the display of the feed application when used in a small container - MEED-10202 - Meeds-io/meeds#4031

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -33,7 +33,7 @@
                   :size="isMobile && '20' || '16'">
                   fa-award
                 </v-icon>
-                <span v-if="!isMobile" class="mx-auto mt-1 mt-lg-0 ms-lg-1 text-body">
+                <span v-if="!isMobile && !$root.reducedWidth" class="mx-auto mt-1 mt-lg-0 ms-lg-1 text-body">
                   {{ $t('exoplatform.kudos.label.kudos') }}
                 </span>
               </div>


### PR DESCRIPTION
This change will improve the display of the feed application when used in a small container by displaying only the kudos icon in the reaction bar.

Resolves: Meeds-io/meeds#4031