### PR TITLE
fix: Display of kudos icon in stream composer input - MEED-10268 - Meeds-io/meeds#4064

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
@@ -27,7 +27,7 @@
         @click="openSendKudosDrawer">
         <v-icon
           size="20px"
-          color="primary">
+          class="icon-default-color">
           fa-award
         </v-icon>
       </v-btn>


### PR DESCRIPTION
Prior to this change, the kudos button in the toolbar composer was displayed using the primary color, which created an inconsistency with the other toolbar buttons. This change applies the default icon color to the kudos button to ensure consistency.
