### PR TITLE
fix: Kudos activity not retrieved in unified search - EXO-87145

### DIFF
--- a/kudos-services/src/main/java/io/meeds/kudos/listener/KudosSentActivityGeneratorListener.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/listener/KudosSentActivityGeneratorListener.java
@@ -138,8 +138,8 @@ public class KudosSentActivityGeneratorListener extends Listener<KudosService, K
     ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
     activity.setParentCommentId(parentCommentId);
     activity.setType(KUDOS_ACTIVITY_COMMENT_TYPE);
-    activity.setTitle(kudos.getMessage());
-    activity.setBody("Kudos to " + kudos.getReceiverFullName());
+    activity.setTitle("Kudos to " + kudos.getReceiverFullName());
+    activity.setBody(kudos.getMessage());
     activity.setUserId(kudos.getSenderIdentityId());
     computeKudosActivityProperties(activity, kudos);
     return activity;


### PR DESCRIPTION
Before this change, when go to spacex and send a kudos to user and click on unified search icon and type the entered message, there is no results displayed when searching for kudos in unified search. To fix this problem, correct the title and the body during the creation of the activity. After this change, the kudos is retreived in unified search as it is an activity.