### PR TITLE
fix: Tooltip displayed on feed after scroll - EXO-87368

### DIFF
--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/KudosButton.vue
@@ -7,10 +7,10 @@
         <div
           class="d-flex"
           v-bind="{
-              ...attrs,
-              role: null,
-              'aria-haspopup': null,
-              'aria-expanded': null}"
+            ...attrs,
+            role: null,
+            'aria-haspopup': null,
+            'aria-expanded': null}"
           v-on="on">
           <v-btn
             :id="`KudosActivity${entityId}`"

--- a/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
+++ b/kudos-webapps/src/main/webapp/vue-app/kudos/components/SendKudosToolbarAction.vue
@@ -15,7 +15,10 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-tooltip v-if="!spaceId" bottom>
+  <v-tooltip
+    v-if="!spaceId"
+    :disabled="isMobile"
+    bottom>
     <template #activator="{ on, attrs }">
       <v-btn
         id="kudosBtnToolbar"
@@ -58,6 +61,11 @@ export default {
     return {
       spaceId: eXo.env.portal.spaceId,
     };
+  },
+  computed: {
+    isMobile() {
+      return this.$vuetify?.breakpoint?.smAndDown;
+    },
   },
   methods: {
     openSendKudosDrawer() {


### PR DESCRIPTION
Prior to this change, in mobile view, long-pressing the send kudos action button would trigger the tooltip, which remained visible even while scrolling the screen. , this change disables the tooltip in mobile view.