### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/kudos-services/src/main/java/io/meeds/kudos/listener/analytics/KudosSentListener.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/listener/analytics/KudosSentListener.java
@@ -141,18 +141,18 @@ public class KudosSentListener extends Listener<KudosService, Kudos> {
     statisticData.setSubModule("kudos");
     statisticData.setOperation("sendKudos");
     statisticData.setUserId(Long.parseLong(kudos.getSenderIdentityId()));
-    statisticData.addParameter("activityId", activityId);
-    statisticData.addParameter("streamIdentityId", streamIdentityId);
-    statisticData.addParameter("kudosId", kudos.getTechnicalId());
-    statisticData.addParameter("senderId", kudos.getSenderIdentityId());
-    statisticData.addParameter("receiverId", kudos.getReceiverIdentityId());
-    statisticData.addParameter("entityId", kudos.getEntityId());
-    statisticData.addParameter("entityType", kudos.getEntityType());
-    statisticData.addParameter("parentEntityId", kudos.getParentEntityId());
-    statisticData.addParameter("receiverType", kudos.getReceiverType());
-    statisticData.addParameter("messageLength", kudos.getMessage().length());
-    statisticData.addParameter("duration", kudos.getTimeInSeconds());
-    statisticData.addParameter("receiverChanged", receiverChanged);
+    statisticData.addKeyword("activityId", activityId);
+    statisticData.addKeyword("streamIdentityId", streamIdentityId);
+    statisticData.addKeyword("kudosId", kudos.getTechnicalId());
+    statisticData.addKeyword("senderId", kudos.getSenderIdentityId());
+    statisticData.addKeyword("receiverId", kudos.getReceiverIdentityId());
+    statisticData.addKeyword("entityId", kudos.getEntityId());
+    statisticData.addKeyword("entityType", kudos.getEntityType());
+    statisticData.addKeyword("parentEntityId", kudos.getParentEntityId());
+    statisticData.addKeyword("receiverType", kudos.getReceiverType());
+    statisticData.addLong("messageLength", kudos.getMessage().length());
+    statisticData.addLong("duration", kudos.getTimeInSeconds());
+    statisticData.addBoolean("receiverChanged", receiverChanged);
 
     AnalyticsUtils.addStatisticData(statisticData);
   }

--- a/kudos-webapps/package-lock.json
+++ b/kudos-webapps/package-lock.json
@@ -5670,9 +5670,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.