### PR TITLE
feat: Add Kudos MCP tools for EVA (send/cancel/list/allowance) - EXO-88391

### DIFF
--- a/kudos-services/pom.xml
+++ b/kudos-services/pom.xml
@@ -47,6 +47,12 @@
       <groupId>io.meeds.social</groupId>
       <artifactId>social-component-notification</artifactId>
     </dependency>
+    <!-- MCP Server API -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.meeds.social</groupId>
@@ -75,6 +81,15 @@
   <build>
     <finalName>kudos-services</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/kudos-services/src/main/java/io/meeds/kudos/mcp/KudosMcpTool.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/mcp/KudosMcpTool.java
@@ -1,0 +1,328 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.kudos.mcp;
+
+import static io.meeds.mcp.server.util.McpToolUtils.formatDate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.kudos.mcp.model.KudosAllowanceModel;
+import io.meeds.kudos.mcp.model.KudosResultModel;
+import io.meeds.kudos.model.AccountSettings;
+import io.meeds.kudos.model.Kudos;
+import io.meeds.kudos.model.KudosEntityType;
+import io.meeds.kudos.model.KudosList;
+import io.meeds.kudos.model.KudosPeriod;
+import io.meeds.kudos.model.KudosPeriodType;
+import io.meeds.kudos.model.exception.KudosAlreadyLinkedException;
+import io.meeds.kudos.service.KudosService;
+import io.meeds.kudos.service.utils.Utils;
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+
+/**
+ * MCP tools exposing the Kudos add-on to the AI agent (EVA). Every method acts
+ * as the current user, so allowance, self-send bans and space redactor rights
+ * are enforced by {@link KudosService}.
+ */
+@Service
+@Profile("mcp-server")
+public class KudosMcpTool implements McpToolPlugin {
+
+  private static final String  USER_RECEIVER_TYPE  = "user";
+
+  private static final String  SPACE_RECEIVER_TYPE = "space";
+
+  private static final int     DEFAULT_LIST_LIMIT  = 10;
+
+  private static final int     MAX_LIST_LIMIT      = 50;
+
+  private final KudosService   kudosService;
+
+  private final SpaceService   spaceService;
+
+  private final IdentityManager identityManager;
+
+  private final ActivityManager activityManager;
+
+  public KudosMcpTool(KudosService kudosService,
+                      SpaceService spaceService,
+                      IdentityManager identityManager,
+                      ActivityManager activityManager) {
+    this.kudosService = kudosService;
+    this.spaceService = spaceService;
+    this.identityManager = identityManager;
+    this.activityManager = activityManager;
+  }
+
+  /**
+   * Sends a kudos from the current user to a user or a space.
+   */
+  public KudosResultModel sendKudos(String receiverType,
+                                    String receiverId,
+                                    String message) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isBlank(message)) {
+      throw new IllegalArgumentException("message is required. A kudos must carry a short appreciation message.");
+    }
+    if (StringUtils.isBlank(receiverId)) {
+      throw new IllegalArgumentException("receiver_id is required. For a user pass the username (resolve it with"
+          + " get_user_by_username); for a space pass its pretty name (resolve it with get_my_spaces).");
+    }
+    String type = StringUtils.trimToEmpty(receiverType).toLowerCase();
+    String currentUser = getCurrentUserName();
+
+    Kudos kudos = new Kudos();
+    kudos.setSenderId(currentUser);
+    kudos.setMessage(message.trim());
+
+    if (USER_RECEIVER_TYPE.equals(type)) {
+      Identity receiver = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, receiverId.trim());
+      if (receiver == null || !receiver.isEnable() || receiver.isDeleted()) {
+        throw new IllegalArgumentException("No enabled user named '" + receiverId
+            + "'. Resolve the exact username with get_user_by_username before sending a kudos.");
+      }
+      if (StringUtils.equalsIgnoreCase(receiver.getRemoteId(), currentUser)) {
+        throw new IllegalStateException("You cannot send a kudos to yourself.");
+      }
+      kudos.setReceiverType(USER_RECEIVER_TYPE);
+      kudos.setReceiverId(receiver.getRemoteId());
+      kudos.setEntityType(KudosEntityType.USER_PROFILE.name());
+      kudos.setEntityId(receiver.getId());
+    } else if (SPACE_RECEIVER_TYPE.equals(type)) {
+      Space space = resolveSpace(receiverId.trim());
+      if (space == null) {
+        throw new IllegalArgumentException("No space found matching '" + receiverId
+            + "'. Resolve the space pretty name with get_my_spaces before sending a kudos.");
+      }
+      Identity spaceIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName());
+      kudos.setReceiverType(SPACE_RECEIVER_TYPE);
+      kudos.setReceiverId(space.getPrettyName());
+      kudos.setSpacePrettyName(space.getPrettyName());
+      kudos.setEntityType(KudosEntityType.SPACE_PROFILE.name());
+      kudos.setEntityId(spaceIdentity == null ? space.getId() : spaceIdentity.getId());
+    } else {
+      throw new IllegalArgumentException("receiver_type must be either 'user' or 'space'.");
+    }
+
+    try {
+      Kudos created = kudosService.createKudos(kudos, currentUser);
+      Utils.transformKudosMessage(created);
+      return toResult(created);
+    } catch (IllegalAccessException e) {
+      throw mapSendError(e);
+    }
+  }
+
+  /**
+   * Cancels (deletes) a kudos previously sent by the current user.
+   */
+  public String cancelKudos(Long kudosId) throws ObjectNotFoundException {
+    if (kudosId == null || kudosId <= 0) {
+      throw new IllegalArgumentException("kudos_id is required and must be a positive number.");
+    }
+    String currentUser = getCurrentUserName();
+    try {
+      kudosService.deleteKudosById(kudosId, currentUser);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You can only cancel a kudos that you sent yourself.");
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No kudos found with id " + kudosId + ". It may have already been cancelled.");
+    } catch (KudosAlreadyLinkedException e) {
+      throw new IllegalStateException("This kudos can no longer be cancelled because other kudos are already linked to it.");
+    }
+    return "Kudos " + kudosId + " has been cancelled.";
+  }
+
+  /**
+   * Returns the current user's remaining kudos allowance for the running
+   * period.
+   */
+  public KudosAllowanceModel getMyKudosAllowance() {
+    String currentUser = getCurrentUserName();
+    AccountSettings settings = kudosService.getAccountSettings(currentUser);
+    KudosPeriod period = kudosService.getCurrentKudosPeriod();
+    KudosPeriodType periodType = kudosService.getDefaultKudosPeriodType();
+    return new KudosAllowanceModel(settings.getRemainingKudos(),
+                                   periodType.name(),
+                                   formatSeconds(period.getStartDateInSeconds()),
+                                   formatSeconds(period.getEndDateInSeconds()));
+  }
+
+  /**
+   * Lists the kudos received by a user or space during the current period.
+   * Defaults to the current user when no identity id is provided.
+   */
+  public KudosList listReceivedKudos(Long identityId, String periodType, Integer limit) {
+    long targetId = (identityId != null && identityId > 0) ? identityId : currentUserIdentityId();
+    KudosPeriodType type = resolvePeriodType(periodType);
+    KudosPeriod period = type.getPeriodOfTime(LocalDateTime.now());
+    int max = clampLimit(limit);
+    long size = kudosService.countKudosByPeriodAndReceiver(targetId,
+                                                           period.getStartDateInSeconds(),
+                                                           period.getEndDateInSeconds());
+    KudosList kudosList = new KudosList();
+    kudosList.setLimit(max);
+    kudosList.setSize(size);
+    if (size == 0) {
+      kudosList.setKudos(List.of());
+      return kudosList;
+    }
+    List<Kudos> kudos = kudosService.getKudosByPeriodAndReceiver(targetId,
+                                                                 period.getStartDateInSeconds(),
+                                                                 period.getEndDateInSeconds(),
+                                                                 max);
+    kudos.forEach(Utils::transformKudosMessage);
+    kudosList.setKudos(kudos);
+    return kudosList;
+  }
+
+  /**
+   * Lists the kudos sent by the current user during the current period. Sent
+   * history defaults to the current user and should not be used to enumerate
+   * other users.
+   */
+  public KudosList listSentKudos(Long identityId, String periodType, Integer limit) {
+    long targetId = (identityId != null && identityId > 0) ? identityId : currentUserIdentityId();
+    KudosPeriodType type = resolvePeriodType(periodType);
+    KudosPeriod period = type.getPeriodOfTime(LocalDateTime.now());
+    int max = clampLimit(limit);
+    long size = kudosService.countKudosByPeriodAndSender(targetId,
+                                                         period.getStartDateInSeconds(),
+                                                         period.getEndDateInSeconds());
+    KudosList kudosList = new KudosList();
+    kudosList.setLimit(max);
+    kudosList.setSize(size);
+    if (size == 0) {
+      kudosList.setKudos(List.of());
+      return kudosList;
+    }
+    List<Kudos> kudos = kudosService.getKudosByPeriodAndSender(targetId,
+                                                               period.getStartDateInSeconds(),
+                                                               period.getEndDateInSeconds(),
+                                                               max);
+    kudos.forEach(Utils::transformKudosMessage);
+    kudosList.setKudos(kudos);
+    return kudosList;
+  }
+
+  /**
+   * Lists the kudos attached to an activity (or its comments), enforcing the
+   * current user's right to view that activity.
+   */
+  public List<Kudos> listKudosOnActivity(String activityId) throws IllegalAccessException {
+    if (StringUtils.isBlank(activityId)) {
+      throw new IllegalArgumentException("activity_id is required.");
+    }
+    try {
+      List<Kudos> kudos = kudosService.getKudosListOfActivity(activityId.trim(), getCurrentUserAclIdentity());
+      kudos.forEach(Utils::transformKudosMessage);
+      return kudos;
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to view kudos on this activity."
+          + " You must be able to view the activity (e.g. be a member of its space).");
+    }
+  }
+
+  private IllegalStateException mapSendError(IllegalAccessException e) {
+    String msg = StringUtils.trimToEmpty(e.getMessage());
+    if (msg.contains("himseld") || msg.contains("himself")) {
+      return new IllegalStateException("You cannot send a kudos to yourself.");
+    }
+    if (msg.contains("send more kudos")) {
+      return new IllegalStateException("You have no kudos left for the current period."
+          + " Call get_my_kudos_allowance to see how many remain and when your allowance resets.");
+    }
+    if (msg.contains("redact on space")) {
+      return new IllegalStateException("You are not allowed to post kudos in that space."
+          + " You must be a space member who is allowed to post (a redactor).");
+    }
+    if (msg.contains("Target space")) {
+      return new IllegalStateException("That space cannot receive this kudos. Check the space with get_my_spaces.");
+    }
+    return new IllegalStateException("Your kudos could not be sent: " + msg);
+  }
+
+  private Space resolveSpace(String id) {
+    Space space = spaceService.getSpaceByPrettyName(id);
+    if (space == null && StringUtils.isNumeric(id)) {
+      space = spaceService.getSpaceById(id);
+    }
+    if (space == null) {
+      space = spaceService.getSpaceByGroupId(id);
+    }
+    if (space == null) {
+      space = spaceService.getSpaceByGroupId("/spaces/" + id);
+    }
+    return space;
+  }
+
+  private long currentUserIdentityId() {
+    Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, getCurrentUserName());
+    if (identity == null) {
+      throw new IllegalStateException("Could not resolve the current user's identity.");
+    }
+    return Long.parseLong(identity.getId());
+  }
+
+  private KudosPeriodType resolvePeriodType(String periodType) {
+    if (StringUtils.isBlank(periodType)) {
+      return kudosService.getDefaultKudosPeriodType();
+    }
+    try {
+      return KudosPeriodType.valueOf(periodType.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid period_type '" + periodType
+          + "'. Allowed values are: WEEK, MONTH, QUARTER, SEMESTER, YEAR.");
+    }
+  }
+
+  private int clampLimit(Integer limit) {
+    if (limit == null || limit <= 0) {
+      return DEFAULT_LIST_LIMIT;
+    }
+    return Math.min(limit, MAX_LIST_LIMIT);
+  }
+
+  private KudosResultModel toResult(Kudos kudos) {
+    return new KudosResultModel(kudos.getTechnicalId(),
+                                kudos.getSenderId(),
+                                kudos.getReceiverId(),
+                                kudos.getReceiverType(),
+                                kudos.getMessage(),
+                                formatSeconds(kudos.getTimeInSeconds()));
+  }
+
+  private String formatSeconds(long seconds) {
+    return seconds <= 0 ? null : formatDate(seconds * 1000);
+  }
+
+}

--- a/kudos-services/src/main/java/io/meeds/kudos/mcp/model/KudosAllowanceModel.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/mcp/model/KudosAllowanceModel.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.kudos.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The current user's remaining Kudos allowance for the running period.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KudosAllowanceModel {
+
+  @JsonProperty("remaining_kudos")
+  private long   remainingKudos;
+
+  @JsonProperty("period_type")
+  private String periodType;
+
+  @JsonProperty("period_start")
+  private String periodStart;
+
+  @JsonProperty("period_end")
+  private String periodEnd;
+
+}

--- a/kudos-services/src/main/java/io/meeds/kudos/mcp/model/KudosResultModel.java
+++ b/kudos-services/src/main/java/io/meeds/kudos/mcp/model/KudosResultModel.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.kudos.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A thin representation of a sent/received Kudos returned to the AI agent.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KudosResultModel {
+
+  @JsonProperty("kudos_id")
+  private Long   id;
+
+  private String sender;
+
+  private String receiver;
+
+  @JsonProperty("receiver_type")
+  private String receiverType;
+
+  private String message;
+
+  @JsonProperty("sent_date")
+  private String sentDate;
+
+}

--- a/kudos-services/src/main/resources/ai-tool-definitions.json
+++ b/kudos-services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,174 @@
+{
+  "tools": [
+    {
+      "name": "send_kudos",
+      "title": "Send a kudos",
+      "description": "Send a kudos (a short public appreciation message) from the current user to a person or a space. Before calling this, check the current user still has kudos left by calling get_my_kudos_allowance. Resolve the receiver first: for a person use get_user_by_username to get the exact username, for a space use get_my_spaces to get its pretty name. Users cannot send a kudos to themselves, and sending to a space requires the current user to be a member who can post (a redactor) in that space.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "receiver_type": {
+            "type": "string",
+            "enum": [
+              "user",
+              "space"
+            ],
+            "description": "Whether the kudos is given to a person ('user') or to a space ('space') (required)."
+          },
+          "receiver_id": {
+            "type": "string",
+            "description": "The receiver identifier (required): for receiver_type 'user' this is the username (resolve with get_user_by_username); for receiver_type 'space' this is the space pretty name (resolve with get_my_spaces)."
+          },
+          "message": {
+            "type": "string",
+            "description": "The appreciation message to attach to the kudos (required)."
+          }
+        },
+        "required": [
+          "receiver_type",
+          "receiver_id",
+          "message"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "cancel_kudos",
+      "title": "Cancel a sent kudos",
+      "description": "Cancel (delete) a kudos that the current user previously sent, identified by its kudos id. Only the sender can cancel their own kudos, and it cannot be cancelled once other kudos are linked to it. Find the kudos id with list_sent_kudos.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "kudos_id": {
+            "type": "integer",
+            "description": "Technical identifier of the kudos to cancel (required). Obtain it from list_sent_kudos."
+          }
+        },
+        "required": [
+          "kudos_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_my_kudos_allowance",
+      "title": "Get my kudos allowance",
+      "description": "Get how many kudos the current user can still send during the running period, along with the period type (WEEK, MONTH, QUARTER, SEMESTER or YEAR) and its start and end dates. Call this before send_kudos to make sure the user still has kudos left.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_received_kudos",
+      "title": "List received kudos",
+      "description": "List the kudos received by a user or a space during a period. If no identity_id is given, it defaults to the current user. Received kudos are public. Use get_my_user_information or search_users to resolve a user's identity id, or get_my_spaces for a space identity id.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "identity_id": {
+            "type": "integer",
+            "description": "Social identity id of the user or space whose received kudos to list. Defaults to the current user when omitted."
+          },
+          "period_type": {
+            "type": "string",
+            "enum": [
+              "WEEK",
+              "MONTH",
+              "QUARTER",
+              "SEMESTER",
+              "YEAR"
+            ],
+            "description": "Period to look at. Defaults to the platform's configured kudos period when omitted."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of kudos to return (default 10, max 50)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_sent_kudos",
+      "title": "List sent kudos",
+      "description": "List the kudos sent by the current user during a period, with their kudos ids (useful before cancel_kudos). Defaults to the current user; do not use it to browse other users' sent kudos.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "identity_id": {
+            "type": "integer",
+            "description": "Social identity id of the sender. Defaults to the current user when omitted; keep it omitted in normal use."
+          },
+          "period_type": {
+            "type": "string",
+            "enum": [
+              "WEEK",
+              "MONTH",
+              "QUARTER",
+              "SEMESTER",
+              "YEAR"
+            ],
+            "description": "Period to look at. Defaults to the platform's configured kudos period when omitted."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of kudos to return (default 10, max 50)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_kudos_on_activity",
+      "title": "List kudos on an activity",
+      "description": "List the kudos attached to an activity (or to its comments), identified by the activity id. The current user must be allowed to view the activity (e.g. be a member of its space).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "activity_id": {
+            "type": "string",
+            "description": "Identifier of the activity whose kudos to list (required)."
+          }
+        },
+        "required": [
+          "activity_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  ]
+}

--- a/kudos-services/src/test/java/io/meeds/kudos/mcp/KudosMcpToolTest.java
+++ b/kudos-services/src/test/java/io/meeds/kudos/mcp/KudosMcpToolTest.java
@@ -1,0 +1,362 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.kudos.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.kudos.mcp.model.KudosAllowanceModel;
+import io.meeds.kudos.mcp.model.KudosResultModel;
+import io.meeds.kudos.model.AccountSettings;
+import io.meeds.kudos.model.Kudos;
+import io.meeds.kudos.model.KudosList;
+import io.meeds.kudos.model.KudosPeriod;
+import io.meeds.kudos.model.KudosPeriodType;
+import io.meeds.kudos.model.exception.KudosAlreadyLinkedException;
+import io.meeds.kudos.service.KudosService;
+import io.meeds.kudos.service.utils.Utils;
+
+class KudosMcpToolTest {
+
+  private static final String                                   USERNAME         = "testuser1";
+
+  private static final String                                   RECEIVER         = "receiver1";
+
+  private static final String                                   USER_IDENTITY_ID = "42";
+
+  private static final String                                   OWN_IDENTITY_ID  = "99";
+
+  private static final String                                   SPACE_PRETTY     = "engineering";
+
+  private static final String                                   SPACE_IDENTITY_ID = "77";
+
+  private static final long                                     KUDOS_ID         = 5L;
+
+  private KudosService                                          kudosService;
+
+  private SpaceService                                          spaceService;
+
+  private IdentityManager                                       identityManager;
+
+  private ActivityManager                                       activityManager;
+
+  private Identity                                              currentIdentity;
+
+  private KudosMcpTool                                          kudosMcpTool;
+
+  private MockedStatic<Utils>                                   utilsMock;
+
+  @BeforeEach
+  void setUp() {
+    kudosService = mock(KudosService.class);
+    spaceService = mock(SpaceService.class);
+    identityManager = mock(IdentityManager.class);
+    activityManager = mock(ActivityManager.class);
+    currentIdentity = new Identity(USERNAME);
+    utilsMock = mockStatic(Utils.class);
+    kudosMcpTool = new KudosMcpTool(kudosService, spaceService, identityManager, activityManager) {
+      @Override
+      public Identity getCurrentUserAclIdentity() {
+        return currentIdentity;
+      }
+    };
+  }
+
+  @AfterEach
+  void tearDown() {
+    utilsMock.close();
+  }
+
+  private org.exoplatform.social.core.identity.model.Identity socialIdentity(String id, String remoteId, boolean enabled) {
+    org.exoplatform.social.core.identity.model.Identity identity =
+        new org.exoplatform.social.core.identity.model.Identity(id);
+    identity.setRemoteId(remoteId);
+    identity.setEnable(enabled);
+    identity.setDeleted(false);
+    return identity;
+  }
+
+  private void stubCurrentUserIdentity() {
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, USERNAME))
+        .thenReturn(socialIdentity(OWN_IDENTITY_ID, USERNAME, true));
+  }
+
+  private Kudos sentKudos(String receiverId, String receiverType) {
+    Kudos kudos = new Kudos();
+    kudos.setTechnicalId(KUDOS_ID);
+    kudos.setSenderId(USERNAME);
+    kudos.setReceiverId(receiverId);
+    kudos.setReceiverType(receiverType);
+    kudos.setMessage("Great work!");
+    kudos.setTimeInSeconds(1_700_000_000L);
+    return kudos;
+  }
+
+  // --- send_kudos ----------------------------------------------------------
+
+  @Test
+  void sendKudosToUser() throws Exception {
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, RECEIVER))
+        .thenReturn(socialIdentity(USER_IDENTITY_ID, RECEIVER, true));
+    when(kudosService.createKudos(any(Kudos.class), eq(USERNAME))).thenReturn(sentKudos(RECEIVER, "user"));
+
+    KudosResultModel result = kudosMcpTool.sendKudos("user", RECEIVER, "Great work!");
+
+    assertNotNull(result);
+    assertEquals(USERNAME, result.getSender());
+    assertEquals(RECEIVER, result.getReceiver());
+    assertEquals("user", result.getReceiverType());
+    verify(kudosService).createKudos(any(Kudos.class), eq(USERNAME));
+  }
+
+  @Test
+  void sendKudosToSpace() throws Exception {
+    Space space = new Space();
+    space.setId("500");
+    space.setPrettyName(SPACE_PRETTY);
+    space.setDisplayName("Engineering");
+    when(spaceService.getSpaceByPrettyName(SPACE_PRETTY)).thenReturn(space);
+    when(identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, SPACE_PRETTY))
+        .thenReturn(socialIdentity(SPACE_IDENTITY_ID, SPACE_PRETTY, true));
+    when(kudosService.createKudos(any(Kudos.class), eq(USERNAME))).thenReturn(sentKudos(SPACE_PRETTY, "space"));
+
+    KudosResultModel result = kudosMcpTool.sendKudos("space", SPACE_PRETTY, "Great work!");
+
+    assertNotNull(result);
+    assertEquals(SPACE_PRETTY, result.getReceiver());
+    assertEquals("space", result.getReceiverType());
+    verify(kudosService).createKudos(any(Kudos.class), eq(USERNAME));
+  }
+
+  @Test
+  void sendKudosBlankMessageFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.sendKudos("user", RECEIVER, "  "));
+  }
+
+  @Test
+  void sendKudosBlankReceiverFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.sendKudos("user", " ", "Great work!"));
+  }
+
+  @Test
+  void sendKudosInvalidTypeFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.sendKudos("group", RECEIVER, "Great work!"));
+  }
+
+  @Test
+  void sendKudosToUnknownUserFails() {
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, RECEIVER)).thenReturn(null);
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.sendKudos("user", RECEIVER, "Great work!"));
+  }
+
+  @Test
+  void sendKudosToSelfFails() {
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, USERNAME))
+        .thenReturn(socialIdentity(OWN_IDENTITY_ID, USERNAME, true));
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.sendKudos("user", USERNAME, "Great work!"));
+  }
+
+  @Test
+  void sendKudosAllowanceExceededFails() throws Exception {
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, RECEIVER))
+        .thenReturn(socialIdentity(USER_IDENTITY_ID, RECEIVER, true));
+    when(kudosService.createKudos(any(Kudos.class), eq(USERNAME)))
+        .thenThrow(new IllegalAccessException("User having username'" + USERNAME + "' is not authorized to send more kudos"));
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.sendKudos("user", RECEIVER, "Great work!"));
+  }
+
+  @Test
+  void sendKudosNotRedactorFails() throws Exception {
+    Space space = new Space();
+    space.setId("500");
+    space.setPrettyName(SPACE_PRETTY);
+    when(spaceService.getSpaceByPrettyName(SPACE_PRETTY)).thenReturn(space);
+    when(identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, SPACE_PRETTY))
+        .thenReturn(socialIdentity(SPACE_IDENTITY_ID, SPACE_PRETTY, true));
+    when(kudosService.createKudos(any(Kudos.class), eq(USERNAME)))
+        .thenThrow(new IllegalAccessException("User cannot redact on space"));
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.sendKudos("space", SPACE_PRETTY, "Great work!"));
+  }
+
+  // --- cancel_kudos --------------------------------------------------------
+
+  @Test
+  void cancelKudos() throws Exception {
+    String result = kudosMcpTool.cancelKudos(KUDOS_ID);
+    assertTrue(result.contains(String.valueOf(KUDOS_ID)));
+    verify(kudosService).deleteKudosById(KUDOS_ID, USERNAME);
+  }
+
+  @Test
+  void cancelKudosInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.cancelKudos(null));
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.cancelKudos(0L));
+  }
+
+  @Test
+  void cancelKudosNotSenderFails() throws Exception {
+    doThrow(new IllegalAccessException("not allowed")).when(kudosService).deleteKudosById(KUDOS_ID, USERNAME);
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.cancelKudos(KUDOS_ID));
+  }
+
+  @Test
+  void cancelKudosNotFoundFails() throws Exception {
+    doThrow(new ObjectNotFoundException("missing")).when(kudosService).deleteKudosById(KUDOS_ID, USERNAME);
+    assertThrows(ObjectNotFoundException.class, () -> kudosMcpTool.cancelKudos(KUDOS_ID));
+  }
+
+  @Test
+  void cancelKudosAlreadyLinkedFails() throws Exception {
+    doThrow(new KudosAlreadyLinkedException("linked")).when(kudosService).deleteKudosById(KUDOS_ID, USERNAME);
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.cancelKudos(KUDOS_ID));
+  }
+
+  // --- get_my_kudos_allowance ----------------------------------------------
+
+  @Test
+  void getMyKudosAllowance() {
+    when(kudosService.getAccountSettings(USERNAME)).thenReturn(new AccountSettings(false, 2L));
+    when(kudosService.getCurrentKudosPeriod()).thenReturn(new KudosPeriod(1_700_000_000L, 1_700_600_000L));
+    when(kudosService.getDefaultKudosPeriodType()).thenReturn(KudosPeriodType.WEEK);
+
+    KudosAllowanceModel allowance = kudosMcpTool.getMyKudosAllowance();
+
+    assertNotNull(allowance);
+    assertEquals(2L, allowance.getRemainingKudos());
+    assertEquals("WEEK", allowance.getPeriodType());
+    assertNotNull(allowance.getPeriodStart());
+    assertNotNull(allowance.getPeriodEnd());
+  }
+
+  // --- list_received_kudos -------------------------------------------------
+
+  @Test
+  void listReceivedKudosDefaultsToSelf() {
+    stubCurrentUserIdentity();
+    when(kudosService.getDefaultKudosPeriodType()).thenReturn(KudosPeriodType.WEEK);
+    when(kudosService.countKudosByPeriodAndReceiver(eq(99L), anyLong(), anyLong())).thenReturn(1L);
+    when(kudosService.getKudosByPeriodAndReceiver(eq(99L), anyLong(), anyLong(), Mockito.anyInt()))
+        .thenReturn(List.of(sentKudos(USERNAME, "user")));
+
+    KudosList list = kudosMcpTool.listReceivedKudos(null, null, null);
+
+    assertNotNull(list);
+    assertEquals(1L, list.getSize());
+    assertEquals(1, list.getKudos().size());
+  }
+
+  @Test
+  void listReceivedKudosEmpty() {
+    when(kudosService.getDefaultKudosPeriodType()).thenReturn(KudosPeriodType.MONTH);
+    when(kudosService.countKudosByPeriodAndReceiver(eq(7L), anyLong(), anyLong())).thenReturn(0L);
+
+    KudosList list = kudosMcpTool.listReceivedKudos(7L, null, null);
+
+    assertNotNull(list);
+    assertEquals(0L, list.getSize());
+    assertTrue(list.getKudos().isEmpty());
+  }
+
+  @Test
+  void listReceivedKudosInvalidPeriodFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.listReceivedKudos(7L, "DECADE", null));
+  }
+
+  // --- list_sent_kudos -----------------------------------------------------
+
+  @Test
+  void listSentKudos() {
+    when(kudosService.getDefaultKudosPeriodType()).thenReturn(KudosPeriodType.WEEK);
+    when(kudosService.countKudosByPeriodAndSender(eq(42L), anyLong(), anyLong())).thenReturn(2L);
+    when(kudosService.getKudosByPeriodAndSender(eq(42L), anyLong(), anyLong(), Mockito.anyInt()))
+        .thenReturn(List.of(sentKudos(RECEIVER, "user"), sentKudos("someone", "user")));
+
+    KudosList list = kudosMcpTool.listSentKudos(42L, "WEEK", 5);
+
+    assertNotNull(list);
+    assertEquals(2L, list.getSize());
+    assertEquals(2, list.getKudos().size());
+  }
+
+  @Test
+  void listSentKudosDefaultsToSelf() {
+    stubCurrentUserIdentity();
+    when(kudosService.getDefaultKudosPeriodType()).thenReturn(KudosPeriodType.WEEK);
+    when(kudosService.countKudosByPeriodAndSender(eq(99L), anyLong(), anyLong())).thenReturn(0L);
+
+    KudosList list = kudosMcpTool.listSentKudos(null, null, null);
+
+    assertNotNull(list);
+    assertEquals(0L, list.getSize());
+    assertTrue(list.getKudos().isEmpty());
+  }
+
+  // --- list_kudos_on_activity ----------------------------------------------
+
+  @Test
+  void listKudosOnActivity() throws Exception {
+    when(kudosService.getKudosListOfActivity(eq("123"), any(Identity.class)))
+        .thenReturn(List.of(sentKudos(RECEIVER, "user")));
+
+    List<Kudos> kudos = kudosMcpTool.listKudosOnActivity("123");
+
+    assertNotNull(kudos);
+    assertEquals(1, kudos.size());
+  }
+
+  @Test
+  void listKudosOnActivityBlankFails() {
+    assertThrows(IllegalArgumentException.class, () -> kudosMcpTool.listKudosOnActivity("  "));
+  }
+
+  @Test
+  void listKudosOnActivityDeniedFails() throws Exception {
+    when(kudosService.getKudosListOfActivity(eq("123"), any(Identity.class)))
+        .thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class, () -> kudosMcpTool.listKudosOnActivity("123"));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <io.meeds.social.version>7.3.x-ai-contribution-SNAPSHOT</io.meeds.social.version>
     <io.meeds.platform-ui.version>7.3.x-ai-contribution-SNAPSHOT</io.meeds.platform-ui.version>
     <addon.meeds.analytics.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.analytics.version>
+    <addon.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.mcp-server.version>
 
     <!-- **************************************** -->
     <!-- Jenkins Settings -->
@@ -81,6 +82,14 @@
         <groupId>io.meeds.analytics</groupId>
         <artifactId>analytics-parent</artifactId>
         <version>${addon.meeds.analytics.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.meeds.mcp-server</groupId>
+        <artifactId>mcp-server</artifactId>
+        <version>${addon.meeds.mcp-server.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Six MCP tools in a new `io.meeds.kudos.mcp` package (`kudos-services`) making kudos fully agent-drivable by EVA. Each is a plain Spring `@Service @Profile("mcp-server")` implementing `McpToolPlugin`, acting **as the current user** (writes are approval-gated). Mirrors the Poll add-on structure.

| Tool | R/W | Backing `KudosService` call |
|------|-----|-----------------------------|
| `send_kudos(receiver_type, receiver_id, message)` | write · approval | `createKudos` — users **and** spaces |
| `cancel_kudos(kudos_id)` | write · approval | `deleteKudosById` |
| `get_my_kudos_allowance()` | read | `getAccountSettings` + period |
| `list_received_kudos(identity_id?, period_type?, limit?)` | read | `getKudosByPeriodAndReceiver` |
| `list_sent_kudos(identity_id?, period_type?, limit?)` | read | `getKudosByPeriodAndSender` (defaults to caller) |
| `list_kudos_on_activity(activity_id)` | read | `getKudosListOfActivity` (ACL-checked) |

The self-send ban, per-period allowance and space-redactor rights are all enforced by `KudosService`; the tools map its exceptions to LLM-directed messages. For a space send, `spacePrettyName` is set and `canRedactOnSpace` applies.

## Wiring
- `kudos-services/pom.xml`: `mcp-server-tools` (provided) dependency + the **`-parameters`** compiler flag (required — MCP args bind to method params by name; without it they bind to null).
- Parent `pom.xml`: `mcp-server` dependencyManagement import. Versions already on the `7.3.x-ai-contribution-SNAPSHOT` line (no bump needed).

## Tests & verification
- 80 tests green (23 new Mockito unit tests for `KudosMcpTool`), coverage gate (0.60) held.
- **Verified live with EVA:** `send_kudos` populated the message, cleared the CometD approval gate and created the kudos (to testuser02); `get_my_kudos_allowance`, `list_received_kudos` and `list_sent_kudos` all returned correct data.

AI contribution. Branch off `feature/ai-contribution`.